### PR TITLE
DG-X/attempt-1: hide display:none items via getHiddenItemIds

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
@@ -78,6 +78,7 @@ import com.liferay.segments.context.RequestContextMapper;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -85,6 +86,7 @@ import java.util.Set;
 
 /**
  * @author Rubén Pulido
+ * @author Gianmarco Brunialti Masera
  */
 public class RenderLayoutStructureDisplayContext {
 
@@ -396,10 +398,36 @@ public class RenderLayoutStructureDisplayContext {
 	}
 
 	public Set<String> getHiddenItemIds() {
+		if (_hiddenItemIds != null) {
+			return _hiddenItemIds;
+		}
+
 		LayoutStructureRulesHelper.LayoutStructureRulesResult
 			layoutStructureRulesResult = getLayoutStructureRulesResult();
 
-		return layoutStructureRulesResult.getHiddenItemIds();
+		Set<String> hiddenItemIds = layoutStructureRulesResult.getHiddenItemIds();
+
+		if (Objects.equals(getLayoutMode(), Constants.EDIT)) {
+			_hiddenItemIds = hiddenItemIds;
+
+			return _hiddenItemIds;
+		}
+
+		Set<String> displayHiddenItemIds = _getDisplayHiddenItemIds();
+
+		if (displayHiddenItemIds.isEmpty()) {
+			_hiddenItemIds = hiddenItemIds;
+
+			return _hiddenItemIds;
+		}
+
+		Set<String> mergedHiddenItemIds = new HashSet<>(hiddenItemIds);
+
+		mergedHiddenItemIds.addAll(displayHiddenItemIds);
+
+		_hiddenItemIds = mergedHiddenItemIds;
+
+		return _hiddenItemIds;
 	}
 
 	public InfoForm getInfoForm(
@@ -735,6 +763,34 @@ public class RenderLayoutStructureDisplayContext {
 		}
 
 		return false;
+	}
+
+	private Set<String> _getDisplayHiddenItemIds() {
+		Set<String> displayHiddenItemIds = new HashSet<>();
+
+		for (LayoutStructureItem layoutStructureItem :
+				_layoutStructure.getLayoutStructureItems()) {
+
+			if (!(layoutStructureItem instanceof StyledLayoutStructureItem)) {
+				continue;
+			}
+
+			StyledLayoutStructureItem styledLayoutStructureItem =
+				(StyledLayoutStructureItem)layoutStructureItem;
+
+			JSONObject stylesJSONObject =
+				styledLayoutStructureItem.getStylesJSONObject();
+
+			if ((stylesJSONObject == null) ||
+				!Objects.equals(stylesJSONObject.getString("display"), "none")) {
+
+				continue;
+			}
+
+			displayHiddenItemIds.add(styledLayoutStructureItem.getItemId());
+		}
+
+		return displayHiddenItemIds;
 	}
 
 	private String _getBackgroundImage(JSONObject jsonObject) {
@@ -1207,6 +1263,7 @@ public class RenderLayoutStructureDisplayContext {
 	private static final Log _log = LogFactoryUtil.getLog(
 		RenderLayoutStructureDisplayContext.class);
 
+	private Set<String> _hiddenItemIds;
 	private final HttpServletRequest _httpServletRequest;
 	private final LayoutStructure _layoutStructure;
 	private LayoutStructureRulesHelper.LayoutStructureRulesResult

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/LayoutStructureCommonStylesCSSServlet.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/LayoutStructureCommonStylesCSSServlet.java
@@ -482,6 +482,13 @@ public class LayoutStructureCommonStylesCSSServlet extends HttpServlet {
 			return false;
 		}
 
+		if (Objects.equals(viewportSize, ViewportSize.DESKTOP) &&
+			Objects.equals(styleName, "display") &&
+			Objects.equals(value, "none")) {
+
+			return false;
+		}
+
 		if (!(styledLayoutStructureItem instanceof
 				ContainerStyledLayoutStructureItem)) {
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/servlet/test/LayoutStructureCommonStylesCSSServletTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/servlet/test/LayoutStructureCommonStylesCSSServletTest.java
@@ -100,6 +100,26 @@ public class LayoutStructureCommonStylesCSSServletTest {
 	}
 
 	@Test
+	public void testDoesNotRenderDesktopDisplayNone() throws Exception {
+		_layoutPageTemplateStructureLocalService.
+			updateLayoutPageTemplateStructureData(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_layout.getPlid(),
+				_read("layout_structure_with_display_none.json"));
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_servlet.service(_getHttpServletRequest(), mockHttpServletResponse);
+
+		Assert.assertEquals(
+			_normalize(mockHttpServletResponse.getContentAsString()),
+			_normalize(
+				COMMON_CSS_STYLE +
+					_read("expected_style_with_display_none.css")));
+	}
+
+	@Test
 	public void testRenderCommonStyles() throws Exception {
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(

--- a/modules/apps/layout/layout-test/src/testIntegration/resources/com/liferay/layout/taglib/servlet/taglib/test/dependencies/expected_style_with_display_none.css
+++ b/modules/apps/layout/layout-test/src/testIntegration/resources/com/liferay/layout/taglib/servlet/taglib/test/dependencies/expected_style_with_display_none.css
@@ -1,0 +1,9 @@
+.lfr-layout-structure-item-z896587a-c659-43f5-9e22 {
+	margin-top: var(--spacer-1, 0.25rem) !important;
+}
+
+@media screen and (max-width: 575px) {
+	.lfr-layout-structure-item-z896587a-c659-43f5-9e22 {
+		display: none !important;
+	}
+}

--- a/modules/apps/layout/layout-test/src/testIntegration/resources/com/liferay/layout/taglib/servlet/taglib/test/dependencies/layout_structure_with_display_none.json
+++ b/modules/apps/layout/layout-test/src/testIntegration/resources/com/liferay/layout/taglib/servlet/taglib/test/dependencies/layout_structure_with_display_none.json
@@ -1,0 +1,38 @@
+{
+	"deletedItems": [
+	],
+	"items": {
+		"root": {
+			"children": [
+				"z896587a-c659-43f5-9e22"
+			],
+			"itemId": "root",
+			"parentId": "",
+			"type": "root"
+		},
+		"z896587a-c659-43f5-9e22": {
+			"children": [
+			],
+			"config": {
+				"portraitMobile": {
+					"styles": {
+						"display": "none"
+					}
+				},
+				"styles": {
+					"display": "none",
+					"marginTop": "1"
+				},
+				"widthType": "fluid"
+			},
+			"itemId": "z896587a-c659-43f5-9e22",
+			"parentId": "root",
+			"type": "container"
+		}
+	},
+	"rootItems": {
+		"dropZone": "",
+		"main": "root"
+	},
+	"version": 1.1
+}


### PR DESCRIPTION
## Summary
Pulls items with `styles.display = "none"` into `getHiddenItemIds()` upstream, then filters orphan `display: none` CSS at desktop. Three commits, scope-split.

## Approach
- `RenderLayoutStructureDisplayContext.getHiddenItemIds()` adds items with `styles.display = "none"` to the hidden set in non-EDIT mode.
- `LayoutStructureCommonStylesCSSServlet._includeStyles` filters desktop `display: none` from the CSS output (the item is skipped at the renderer, so the CSS would target nothing).
- Integration test `testDoesNotRenderDesktopDisplayNone` in `LayoutStructureCommonStylesCSSServletTest` verifies the CSS filter (positive case at desktop, negative case at portrait mobile).

## Test plan
- [ ] Run `LayoutStructureCommonStylesCSSServletTest.testDoesNotRenderDesktopDisplayNone`
- [ ] Manually: hide a fragment in the page builder, view the published page, confirm the fragment isn't in the DOM