### PR TITLE
DG-X/attempt-2: skip display:none items in renderer

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
@@ -60,11 +60,13 @@ import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructureItemUtil;
 import com.liferay.layout.util.structure.RowStyledLayoutStructureItem;
+import com.liferay.layout.util.structure.StyledLayoutStructureItem;
 import com.liferay.layout.util.structure.collection.EmptyCollectionOptions;
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
@@ -107,6 +109,7 @@ import java.util.Set;
 
 /**
  * @author Mikel Lorza
+ * @author Gianmarco Brunialti Masera
  */
 public class LayoutStructureRenderer {
 
@@ -266,6 +269,33 @@ public class LayoutStructureRenderer {
 		}
 
 		return false;
+	}
+
+	private boolean _isHiddenByDisplayStyle(
+		LayoutStructureItem layoutStructureItem) {
+
+		if (Objects.equals(
+				_renderLayoutStructureDisplayContext.getLayoutMode(),
+				Constants.EDIT)) {
+
+			return false;
+		}
+
+		if (!(layoutStructureItem instanceof StyledLayoutStructureItem)) {
+			return false;
+		}
+
+		StyledLayoutStructureItem styledLayoutStructureItem =
+			(StyledLayoutStructureItem)layoutStructureItem;
+
+		JSONObject stylesJSONObject =
+			styledLayoutStructureItem.getStylesJSONObject();
+
+		if (stylesJSONObject == null) {
+			return false;
+		}
+
+		return Objects.equals(stylesJSONObject.getString("display"), "none");
 	}
 
 	private void _renderCol(
@@ -1722,7 +1752,9 @@ public class LayoutStructureRenderer {
 			LayoutStructureItem layoutStructureItem =
 				_layoutStructure.getLayoutStructureItem(childrenItemId);
 
-			if (hiddenItemIds.contains(childrenItemId)) {
+			if (hiddenItemIds.contains(childrenItemId) ||
+				_isHiddenByDisplayStyle(layoutStructureItem)) {
+
 				continue;
 			}
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
@@ -3157,6 +3157,84 @@ public class RenderLayoutStructureTagTest {
 	}
 
 	@Test
+	public void testRenderHidesItemWithDisplayNone() throws Exception {
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			LayoutPageTemplateStructureLocalServiceUtil.
+				fetchLayoutPageTemplateStructure(
+					_group.getGroupId(), draftLayout.getPlid());
+
+		LayoutStructure layoutStructure = LayoutStructure.of(
+			layoutPageTemplateStructure.getDefaultSegmentsExperienceData());
+
+		ContainerStyledLayoutStructureItem containerStyledLayoutStructureItem =
+			(ContainerStyledLayoutStructureItem)
+				layoutStructure.addContainerStyledLayoutStructureItem(
+					layoutStructure.getMainItemId(), 0);
+
+		containerStyledLayoutStructureItem.updateItemConfig(
+			JSONUtil.put(
+				"styles", JSONUtil.put("display", "none")));
+
+		_layoutPageTemplateStructureLocalService.
+			updateLayoutPageTemplateStructureData(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				draftLayout.getPlid(),
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(draftLayout.getPlid()),
+				layoutStructure.toString());
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		String content = _getRenderLayoutHTML(layout);
+
+		Assert.assertFalse(
+			content,
+			content.contains(
+				containerStyledLayoutStructureItem.getUniqueCssClass()));
+	}
+
+	@Test
+	public void testRenderShowsItemWithoutDisplayNone() throws Exception {
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			LayoutPageTemplateStructureLocalServiceUtil.
+				fetchLayoutPageTemplateStructure(
+					_group.getGroupId(), draftLayout.getPlid());
+
+		LayoutStructure layoutStructure = LayoutStructure.of(
+			layoutPageTemplateStructure.getDefaultSegmentsExperienceData());
+
+		ContainerStyledLayoutStructureItem containerStyledLayoutStructureItem =
+			(ContainerStyledLayoutStructureItem)
+				layoutStructure.addContainerStyledLayoutStructureItem(
+					layoutStructure.getMainItemId(), 0);
+
+		_layoutPageTemplateStructureLocalService.
+			updateLayoutPageTemplateStructureData(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				draftLayout.getPlid(),
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(draftLayout.getPlid()),
+				layoutStructure.toString());
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		String content = _getRenderLayoutHTML(layout);
+
+		Assert.assertTrue(
+			content,
+			content.contains(
+				containerStyledLayoutStructureItem.getUniqueCssClass()));
+	}
+
+	@Test
 	@TestInfo("LPD-82690")
 	public void testRenderJournalArticle() throws Exception {
 		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);


### PR DESCRIPTION
## Summary
Skips items with `styles.display = "none"` directly in `LayoutStructureRenderer` instead of routing through `getHiddenItemIds`. Two commits.

## Approach
- New `_isHiddenByDisplayStyle` helper in `LayoutStructureRenderer` short-circuits the children loop in non-EDIT mode when a styled item has `styles.display = "none"`.
- No changes to the display context or CSS servlet — orphan `display: none` CSS is harmless (no element to target).
- Integration tests `testRenderHidesItemWithDisplayNone` and `testRenderShowsItemWithoutDisplayNone` in `RenderLayoutStructureTagTest` assert the item's unique CSS class is absent / present in the published HTML.

## Trade-off vs. attempt-1
- Attempt-1 centralizes in the display context (any consumer of `getHiddenItemIds` benefits) but spreads logic across two files.
- Attempt-2 keeps the change localized to the renderer; only the renderer benefits.

## Test plan
- [ ] Run `RenderLayoutStructureTagTest.testRenderHidesItemWithDisplayNone`
- [ ] Run `RenderLayoutStructureTagTest.testRenderShowsItemWithoutDisplayNone`
- [ ] Manually: hide a fragment in the page builder, view the published page, confirm the fragment isn't in the DOM