### PR TITLE
DG-X/attempt-3: dedicated hidden flag, drop display:none marker

### DIFF
--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/StyledLayoutStructureItem.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/StyledLayoutStructureItem.java
@@ -36,6 +36,7 @@ import java.util.Set;
 
 /**
  * @author Pavel Savinov
+ * @author Gianmarco Brunialti Masera
  */
 public abstract class StyledLayoutStructureItem extends LayoutStructureItem {
 
@@ -109,6 +110,8 @@ public abstract class StyledLayoutStructureItem extends LayoutStructureItem {
 		).put(
 			"customCSS", _customCSS
 		).put(
+			"hidden", _hidden
+		).put(
 			"name", _name
 		).put(
 			"styles", stylesJSONObject
@@ -137,6 +140,10 @@ public abstract class StyledLayoutStructureItem extends LayoutStructureItem {
 
 	public String getName() {
 		return _name;
+	}
+
+	public boolean isHidden() {
+		return _hidden;
 	}
 
 	public String getStyledCssClasses() {
@@ -168,6 +175,10 @@ public abstract class StyledLayoutStructureItem extends LayoutStructureItem {
 		_customCSSViewports.put(viewportSizeId, customCSS);
 	}
 
+	public void setHidden(boolean hidden) {
+		_hidden = hidden;
+	}
+
 	public void setName(String name) {
 		_name = name;
 	}
@@ -185,6 +196,10 @@ public abstract class StyledLayoutStructureItem extends LayoutStructureItem {
 
 		if (itemConfigJSONObject.has("customCSS")) {
 			setCustomCSS(itemConfigJSONObject.getString("customCSS"));
+		}
+
+		if (itemConfigJSONObject.has("hidden")) {
+			setHidden(itemConfigJSONObject.getBoolean("hidden"));
 		}
 
 		if (itemConfigJSONObject.has("name")) {
@@ -425,6 +440,7 @@ public abstract class StyledLayoutStructureItem extends LayoutStructureItem {
 	private Set<String> _cssClasses;
 	private String _customCSS;
 	private final Map<String, String> _customCSSViewports = new HashMap<>();
+	private boolean _hidden;
 	private String _name;
 
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/hideFragment.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/hideFragment.js
@@ -3,14 +3,13 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import updateItemStyle from './updateItemStyle';
+import updateItemConfig from '../thunks/updateItemConfig';
 
-export default function hideFragment({dispatch, itemId, selectedViewportSize}) {
-	updateItemStyle({
-		dispatch,
-		itemIds: [itemId],
-		selectedViewportSize,
-		styleName: 'display',
-		styleValue: 'none',
-	});
+export default function hideFragment({dispatch, itemId}) {
+	dispatch(
+		updateItemConfig({
+			itemConfig: {hidden: true},
+			itemIds: [itemId],
+		})
+	);
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/isItemHidden.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/isItemHidden.ts
@@ -5,12 +5,11 @@
 
 import {LayoutData, LayoutDataItem} from '../../types/layout_data/LayoutData';
 import {ViewportSize} from '../config/constants/viewportSizes';
-import {getResponsiveConfig} from '../js-index';
 
 export function isItemHidden(
 	layoutData: LayoutData,
 	itemId: LayoutDataItem['itemId'],
-	selectedViewportSize: ViewportSize,
+	_selectedViewportSize?: ViewportSize,
 	options = {recursive: false}
 ): boolean {
 	const item = layoutData?.items[itemId];
@@ -19,22 +18,17 @@ export function isItemHidden(
 		return false;
 	}
 
-	const responsiveConfig = getResponsiveConfig(
-		item.config,
-		selectedViewportSize
-	);
-
 	if (options.recursive) {
 		return (
-			responsiveConfig.styles.display === 'none' ||
+			item.config?.hidden === true ||
 			isItemHidden(
 				layoutData,
 				item.parentId,
-				selectedViewportSize,
+				_selectedViewportSize,
 				options
 			)
 		);
 	}
 
-	return responsiveConfig.styles.display === 'none';
+	return item.config?.hidden === true;
 }

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
@@ -60,6 +60,7 @@ import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructureItemUtil;
 import com.liferay.layout.util.structure.RowStyledLayoutStructureItem;
+import com.liferay.layout.util.structure.StyledLayoutStructureItem;
 import com.liferay.layout.util.structure.collection.EmptyCollectionOptions;
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.petra.string.StringBundler;
@@ -107,6 +108,7 @@ import java.util.Set;
 
 /**
  * @author Mikel Lorza
+ * @author Gianmarco Brunialti Masera
  */
 public class LayoutStructureRenderer {
 
@@ -266,6 +268,21 @@ public class LayoutStructureRenderer {
 		}
 
 		return false;
+	}
+
+	private boolean _isHiddenItem(LayoutStructureItem layoutStructureItem) {
+		if (Objects.equals(
+				_renderLayoutStructureDisplayContext.getLayoutMode(),
+				Constants.EDIT)) {
+
+			return false;
+		}
+
+		if (!(layoutStructureItem instanceof StyledLayoutStructureItem)) {
+			return false;
+		}
+
+		return ((StyledLayoutStructureItem)layoutStructureItem).isHidden();
 	}
 
 	private void _renderCol(
@@ -1722,7 +1739,9 @@ public class LayoutStructureRenderer {
 			LayoutStructureItem layoutStructureItem =
 				_layoutStructure.getLayoutStructureItem(childrenItemId);
 
-			if (hiddenItemIds.contains(childrenItemId)) {
+			if (hiddenItemIds.contains(childrenItemId) ||
+				_isHiddenItem(layoutStructureItem)) {
+
 				continue;
 			}
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
@@ -3157,6 +3157,83 @@ public class RenderLayoutStructureTagTest {
 	}
 
 	@Test
+	public void testRenderHidesItemMarkedAsHidden() throws Exception {
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			LayoutPageTemplateStructureLocalServiceUtil.
+				fetchLayoutPageTemplateStructure(
+					_group.getGroupId(), draftLayout.getPlid());
+
+		LayoutStructure layoutStructure = LayoutStructure.of(
+			layoutPageTemplateStructure.getDefaultSegmentsExperienceData());
+
+		ContainerStyledLayoutStructureItem containerStyledLayoutStructureItem =
+			(ContainerStyledLayoutStructureItem)
+				layoutStructure.addContainerStyledLayoutStructureItem(
+					layoutStructure.getMainItemId(), 0);
+
+		containerStyledLayoutStructureItem.updateItemConfig(
+			JSONUtil.put("hidden", true));
+
+		_layoutPageTemplateStructureLocalService.
+			updateLayoutPageTemplateStructureData(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				draftLayout.getPlid(),
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(draftLayout.getPlid()),
+				layoutStructure.toString());
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		String content = _getRenderLayoutHTML(layout);
+
+		Assert.assertFalse(
+			content,
+			content.contains(
+				containerStyledLayoutStructureItem.getUniqueCssClass()));
+	}
+
+	@Test
+	public void testRenderShowsItemNotMarkedAsHidden() throws Exception {
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			LayoutPageTemplateStructureLocalServiceUtil.
+				fetchLayoutPageTemplateStructure(
+					_group.getGroupId(), draftLayout.getPlid());
+
+		LayoutStructure layoutStructure = LayoutStructure.of(
+			layoutPageTemplateStructure.getDefaultSegmentsExperienceData());
+
+		ContainerStyledLayoutStructureItem containerStyledLayoutStructureItem =
+			(ContainerStyledLayoutStructureItem)
+				layoutStructure.addContainerStyledLayoutStructureItem(
+					layoutStructure.getMainItemId(), 0);
+
+		_layoutPageTemplateStructureLocalService.
+			updateLayoutPageTemplateStructureData(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				draftLayout.getPlid(),
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(draftLayout.getPlid()),
+				layoutStructure.toString());
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		String content = _getRenderLayoutHTML(layout);
+
+		Assert.assertTrue(
+			content,
+			content.contains(
+				containerStyledLayoutStructureItem.getUniqueCssClass()));
+	}
+
+	@Test
 	@TestInfo("LPD-82690")
 	public void testRenderJournalArticle() throws Exception {
 		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);


### PR DESCRIPTION
## Summary
Drops `display: none` as the hidden-fragment marker entirely; introduces a dedicated `hidden` boolean flag on `StyledLayoutStructureItem`. Two commits.

## Approach
**Backend**
- `StyledLayoutStructureItem` gains `_hidden` field, `isHidden()`, `setHidden(boolean)`, plus serialization in `getItemConfigJSONObject()` and parsing in `updateItemConfig()`.
- `LayoutStructureRenderer._isHiddenItem` short-circuits the children loop in non-EDIT mode when `isHidden()` is true.

**Page builder UI**
- `hideFragment.js` dispatches `updateItemConfig({hidden: true, ...})` instead of `updateItemStyle({styleName: 'display', styleValue: 'none'})`.
- `isItemHidden.ts` reads `item.config?.hidden` instead of `responsiveConfig.styles.display === 'none'`. Viewport arg kept for caller compatibility but unused — the flag is viewport-independent by design.

## Trade-off vs. attempts 1 & 2
- Attempts 1/2 keep the existing `display: none` data model and intercept on the read side.
- Attempt-3 changes the data model: hide is a structural decision, not a responsive style. Cleaner long-term but requires migration for existing pages and a few follow-ups (sidebar `HideFragmentField` checkbox + `common-styles.json` `hideFragment` field type still write to `styles.display`).

## Test plan
- [ ] Run `RenderLayoutStructureTagTest.testRenderHidesItemMarkedAsHidden`
- [ ] Run `RenderLayoutStructureTagTest.testRenderShowsItemNotMarkedAsHidden`
- [ ] Manually: hide a fragment via the topper menu in the page builder, view the published page, confirm the fragment isn't in the DOM
- [ ] Manually: confirm hidden items are still visible in EDIT mode

## Known follow-ups
- Sidebar `HideFragmentField` checkbox and `common-styles.json` `hideFragment` field type still write to `styles.display` — needs migration.
- No automatic upgrade of pages already storing `styles.display = "none"`; those will continue rendering until re-saved through the new flow.