### PR TITLE
DG-X Add liferay-dotcom-foundations-global-css client extension

### DIFF
--- a/workspaces/liferay-dotcom-workspace/client-extensions/liferay-dotcom-foundations-global-css/assets/foundations.css
+++ b/workspaces/liferay-dotcom-workspace/client-extensions/liferay-dotcom-foundations-global-css/assets/foundations.css
@@ -1,0 +1,3986 @@
+.color-transparent {
+  color: "transparent";
+}
+
+.bg-transparent {
+  background-color: "transparent";
+}
+
+.color-black {
+  color: var(--black);
+}
+
+.bg-black {
+  background-color: var(--black);
+}
+
+.color-primary {
+  color: var(--primary);
+}
+
+.bg-primary {
+  background-color: var(--primary);
+}
+
+.color-primary-10 {
+  color: var(--primary-10);
+}
+
+.bg-primary-10 {
+  background-color: var(--primary-10);
+}
+
+.color-primary-5 {
+  color: var(--primary-5);
+}
+
+.bg-primary-5 {
+  background-color: var(--primary-5);
+}
+
+.color-primary-7 {
+  color: var(--primary-7);
+}
+
+.bg-primary-7 {
+  background-color: var(--primary-7);
+}
+
+.color-primary-dark {
+  color: var(--primary-dark);
+}
+
+.bg-primary-dark {
+  background-color: var(--primary-dark);
+}
+
+.color-white {
+  color: var(--white);
+}
+
+.bg-white {
+  background-color: var(--white);
+}
+
+.color-accent-1 {
+  color: var(--accent-1);
+}
+
+.bg-accent-1 {
+  background-color: var(--accent-1);
+}
+
+.color-accent-2 {
+  color: var(--accent-2);
+}
+
+.bg-accent-2 {
+  background-color: var(--accent-2);
+}
+
+.color-accent-3 {
+  color: var(--accent-3);
+}
+
+.bg-accent-3 {
+  background-color: var(--accent-3);
+}
+
+.color-accent-4 {
+  color: var(--accent-4);
+}
+
+.bg-accent-4 {
+  background-color: var(--accent-4);
+}
+
+.color-accent-5 {
+  color: var(--accent-5);
+}
+
+.bg-accent-5 {
+  background-color: var(--accent-5);
+}
+
+.color-accent-6 {
+  color: var(--accent-6);
+}
+
+.bg-accent-6 {
+  background-color: var(--accent-6);
+}
+
+.color-accent-7 {
+  color: var(--accent-7);
+}
+
+.bg-accent-7 {
+  background-color: var(--accent-7);
+}
+
+.color-accent-8 {
+  color: var(--accent-8);
+}
+
+.bg-accent-8 {
+  background-color: var(--accent-8);
+}
+
+.color-accent-9 {
+  color: var(--accent-9);
+}
+
+.bg-accent-9 {
+  background-color: var(--accent-9);
+}
+
+.color-accent-10 {
+  color: var(--accent-10);
+}
+
+.bg-accent-10 {
+  background-color: var(--accent-10);
+}
+
+.color-neutral-1 {
+  color: var(--neutral-1);
+}
+
+.bg-neutral-1 {
+  background-color: var(--neutral-1);
+}
+
+.color-neutral-2 {
+  color: var(--neutral-2);
+}
+
+.bg-neutral-2 {
+  background-color: var(--neutral-2);
+}
+
+.color-neutral-3 {
+  color: var(--neutral-3);
+}
+
+.bg-neutral-3 {
+  background-color: var(--neutral-3);
+}
+
+.color-neutral-4 {
+  color: var(--neutral-4);
+}
+
+.bg-neutral-4 {
+  background-color: var(--neutral-4);
+}
+
+.color-neutral-5 {
+  color: var(--neutral-5);
+}
+
+.bg-neutral-5 {
+  background-color: var(--neutral-5);
+}
+
+.color-neutral-6 {
+  color: var(--neutral-6);
+}
+
+.bg-neutral-6 {
+  background-color: var(--neutral-6);
+}
+
+.color-neutral-7 {
+  color: var(--neutral-7);
+}
+
+.bg-neutral-7 {
+  background-color: var(--neutral-7);
+}
+
+.color-neutral-8 {
+  color: var(--neutral-8);
+}
+
+.bg-neutral-8 {
+  background-color: var(--neutral-8);
+}
+
+.color-neutral-9 {
+  color: var(--neutral-9);
+}
+
+.bg-neutral-9 {
+  background-color: var(--neutral-9);
+}
+
+.color-action-default {
+  color: var(--action-default);
+}
+
+.bg-action-default {
+  background-color: var(--action-default);
+}
+
+.color-action-default-hover {
+  color: var(--action-default-hover);
+}
+
+.bg-action-default-hover {
+  background-color: var(--action-default-hover);
+}
+
+.color-action-default-active {
+  color: var(--action-default-active);
+}
+
+.bg-action-default-active {
+  background-color: var(--action-default-active);
+}
+
+.color-action-secondary {
+  color: var(--action-secondary);
+}
+
+.bg-action-secondary {
+  background-color: var(--action-secondary);
+}
+
+.color-action-secondary-hover {
+  color: var(--action-secondary-hover);
+}
+
+.bg-action-secondary-hover {
+  background-color: var(--action-secondary-hover);
+}
+
+.color-action-secondary-active {
+  color: var(--action-secondary-active);
+}
+
+.bg-action-secondary-active {
+  background-color: var(--action-secondary-active);
+}
+
+.color-action-visited {
+  color: var(--action-visited);
+}
+
+.bg-action-visited {
+  background-color: var(--action-visited);
+}
+
+.color-function-error {
+  color: #da1414;
+}
+
+.bg-function-error {
+  background-color: #da1414;
+}
+
+.color-function-error-border {
+  color: #f48989;
+}
+
+.bg-function-error-border {
+  background-color: #f48989;
+}
+
+.color-function-error-background {
+  color: #feefef;
+}
+
+.bg-function-error-background {
+  background-color: #feefef;
+}
+
+.color-function-warning {
+  color: #b95000;
+}
+
+.bg-function-warning {
+  background-color: #b95000;
+}
+
+.color-function-warning-border {
+  color: #ff8f3a;
+}
+
+.bg-function-warning-border {
+  background-color: #ff8f3a;
+}
+
+.color-function-warning-background {
+  color: #fff4ec;
+}
+
+.bg-function-warning-background {
+  background-color: #fff4ec;
+}
+
+.color-function-success {
+  color: #287d3c;
+}
+
+.bg-function-success {
+  background-color: #287d3c;
+}
+
+.color-function-success-border {
+  color: #5aca75;
+}
+
+.bg-function-success-border {
+  background-color: #5aca75;
+}
+
+.color-function-success-background {
+  color: #edf9f0;
+}
+
+.bg-function-success-background {
+  background-color: #edf9f0;
+}
+
+.color-function-info {
+  color: #89a7e0;
+}
+
+.bg-function-info {
+  background-color: #89a7e0;
+}
+
+.color-function-info-border {
+  color: #89a7e0;
+}
+
+.bg-function-info-border {
+  background-color: #89a7e0;
+}
+
+.color-function-info-background {
+  color: #eef2fa;
+}
+
+.bg-function-info-background {
+  background-color: #eef2fa;
+}
+
+.elevation-1 {
+  box-shadow: 0px 0.5px 3.35px 0px rgba(0, 0, 0, 0.14), 0px 1px 1.5px 0px rgba(0, 0, 0, 0.032), 0px 2.3px 2px -0.6px rgba(0, 0, 0, 0.06);
+}
+
+.elevation-2 {
+  box-shadow: 0px 0.8px 3.7px -0.33px rgba(0, 0, 0, 0.14), 0px 2px 3px 0.15px rgba(0, 0, 0, 0.034), 0px 2.6px 4px -0.2px rgba(0, 0, 0, 0.06);
+}
+
+.elevation-3 {
+  box-shadow: 0px 1.1px 4.05px -0.66px rgba(0, 0, 0, 0.14), 0px 3px 4.5px 0.3px rgba(0, 0, 0, 0.036), 0px 2.9px 6px 0.2px rgba(0, 0, 0, 0.06);
+}
+
+.elevation-4 {
+  box-shadow: 0px 1.4px 4.4px -0.99px rgba(0, 0, 0, 0.14), 0px 4px 6px 0.45px rgba(0, 0, 0, 0.038), 0px 3.2px 8px 0.6px rgba(0, 0, 0, 0.06);
+}
+
+.elevation-5 {
+  box-shadow: 0px 2px 5.1px -1.65px rgba(0, 0, 0, 0.14), 0px 6px 9px 0.75px rgba(0, 0, 0, 0.042), 0px 3.8px 12px 1.4px rgba(0, 0, 0, 0.06);
+}
+
+.elevation-6 {
+  box-shadow: 0px 2.6px 5.8px -2.31px rgba(0, 0, 0, 0.14), 0px 8px 12px 1.05px rgba(0, 0, 0, 0.046), 0px 4.4px 16px 2.2px rgba(0, 0, 0, 0.06);
+}
+
+.elevation-7 {
+  box-shadow: 0px 3.5px 6.85px -3.3px rgba(0, 0, 0, 0.14), 0px 11px 16.5px 1.5px rgba(0, 0, 0, 0.052), 0px 5.3px 22px 3.4px rgba(0, 0, 0, 0.06);
+}
+
+.elevation-8 {
+  box-shadow: 0px 4.7px 8.25px -4.62px rgba(0, 0, 0, 0.14), 0px 15px 22.5px 2.1px rgba(0, 0, 0, 0.06), 0px 6.5px 30px 5px rgba(0, 0, 0, 0.06);
+}
+
+.elevation-9 {
+  box-shadow: 0px 7.4px 11.4px -7.59px rgba(0, 0, 0, 0.14), 0px 24px 36px 3.45px rgba(0, 0, 0, 0.078), 0px 9.2px 48px 8.6px rgba(0, 0, 0, 0.06);
+}
+
+.align-baseline {
+  align-items: baseline;
+}
+
+.align-center {
+  align-items: center;
+}
+
+.align-end {
+  align-items: flex-end;
+}
+
+.align-space-around {
+  align-items: space-around;
+}
+
+.align-space-between {
+  align-items: space-between;
+}
+
+.align-start {
+  align-items: flex-start;
+}
+
+.align-stretch {
+  align-items: stretch;
+}
+
+.align-content-baseline {
+  align-content: baseline;
+}
+
+.align-content-center {
+  align-content: center;
+}
+
+.align-content-end {
+  align-content: flex-end;
+}
+
+.align-content-space-around {
+  align-content: space-around;
+}
+
+.align-content-space-between {
+  align-content: space-between;
+}
+
+.align-content-start {
+  align-content: flex-start;
+}
+
+.align-content-stretch {
+  align-content: stretch;
+}
+
+.justify-baseline {
+  justify-content: baseline;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.justify-end {
+  justify-content: flex-end;
+}
+
+.justify-space-around {
+  justify-content: space-around;
+}
+
+.justify-space-between {
+  justify-content: space-between;
+}
+
+.justify-start {
+  justify-content: flex-start;
+}
+
+.justify-stretch {
+  justify-content: stretch;
+}
+
+.flex-column {
+  flex-direction: column;
+}
+
+.flex-column-reverse {
+  flex-direction: column-reverse;
+}
+
+.flex-row {
+  flex-direction: row;
+}
+
+.flex-row-reverse {
+  flex-direction: row-reverse;
+}
+
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
+.flex-nowrap {
+  flex-wrap: nowrap;
+}
+
+.flex {
+  display: flex;
+}
+
+html .content #main-content.layout-content {
+  margin: 0;
+  max-width: none;
+}
+
+.layout-content .container {
+  max-width: 1366px;
+}
+.layout-content .container.sidebar-layouts-section__layout-preview {
+  padding: 0;
+}
+.layout-content .container.sidebar-layouts-section__layout-preview .sidebar-layouts-section__layout-preview__row {
+  margin: 0;
+}
+@media (max-width: 599px) {
+  .layout-content .container {
+    padding-left: 1.5rem !important;
+    padding-right: 1.5rem !important;
+  }
+  .layout-content div[class*=col-md] {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+  .layout-content .row {
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+  }
+}
+@media (min-width: 600px) {
+  .layout-content .container {
+    padding-left: 1.5rem !important;
+    padding-right: 1.5rem !important;
+  }
+  .layout-content div[class*=col-md] {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+  .layout-content .row {
+    margin-left: -0.75rem;
+    margin-right: -0.75rem;
+  }
+}
+@media (min-width: 900px) {
+  .layout-content .container {
+    padding-left: 4rem !important;
+    padding-right: 4rem !important;
+  }
+  .layout-content div[class*=col-md] {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+  .layout-content .row {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+}
+
+.max-width-none {
+  max-width: "none";
+}
+
+.max-width-xsmall {
+  max-width: 320px;
+}
+
+.max-width-form-small {
+  max-width: 400px;
+}
+
+.max-width-form {
+  max-width: 500px;
+}
+
+.max-width-small {
+  max-width: 520px;
+}
+
+.max-width-medium {
+  max-width: 720px;
+}
+
+.max-width-large {
+  max-width: 900px;
+}
+
+.max-width-xlarge {
+  max-width: 1200px;
+}
+
+.max-width-full {
+  max-width: 1366px;
+}
+
+.border-radius-none {
+  border-radius: 0;
+}
+
+.border-radius-small {
+  border-radius: 2px;
+}
+
+.border-radius-medium {
+  border-radius: 4px;
+}
+
+.border-radius-large {
+  border-radius: 6px;
+}
+
+.border-radius-xlarge {
+  border-radius: 8px;
+}
+
+.font-family-mono {
+  font-family: "Source Code Pro", Menlo, monospace;
+}
+.font-family-sans {
+  font-family: "Source Sans Pro", Tahoma, "Trebuchet MS", sans-serif;
+}
+.font-family-serif {
+  font-family: "Source Serif Pro", Georgia, Cambria, "Times New Roman", Times, serif;
+}
+
+.font-weight-bold {
+  font-weight: 700;
+}
+.font-weight-extra-light {
+  font-weight: 200;
+}
+.font-weight-light {
+  font-weight: 300;
+}
+.font-weight-normal {
+  font-weight: 400;
+}
+.font-weight-semi-bold {
+  font-weight: 600;
+}
+
+.content .layout-content h1, .font-size-heading-f1 {
+  font-weight: 600;
+}
+@media (max-width: 599px) {
+  .content .layout-content h1, .font-size-heading-f1 {
+    font-size: 2rem;
+    line-height: 1.125;
+  }
+}
+@media (min-width: 600px) {
+  .content .layout-content h1, .font-size-heading-f1 {
+    font-size: 2.625rem;
+    line-height: 1.143;
+  }
+}
+@media (min-width: 900px) {
+  .content .layout-content h1, .font-size-heading-f1 {
+    font-size: 3rem;
+    line-height: 1.167;
+  }
+}
+@media (min-width: 1200px) {
+  .content .layout-content h1, .font-size-heading-f1 {
+    font-size: 3.438rem;
+    line-height: 1.018;
+  }
+}
+
+.content .layout-content h2, .font-size-heading-f2 {
+  font-weight: 600;
+}
+@media (max-width: 599px) {
+  .content .layout-content h2, .font-size-heading-f2 {
+    font-size: 1.813rem;
+    line-height: 1.103;
+  }
+}
+@media (min-width: 600px) {
+  .content .layout-content h2, .font-size-heading-f2 {
+    font-size: 2.188rem;
+    line-height: 1.029;
+  }
+}
+@media (min-width: 900px) {
+  .content .layout-content h2, .font-size-heading-f2 {
+    font-size: 2.438rem;
+    line-height: 1.026;
+  }
+}
+@media (min-width: 1200px) {
+  .content .layout-content h2, .font-size-heading-f2 {
+    font-size: 2.75rem;
+    line-height: 1.091;
+  }
+}
+
+.content .layout-content h3, .font-size-heading-f3 {
+  font-weight: 600;
+}
+@media (max-width: 599px) {
+  .content .layout-content h3, .font-size-heading-f3 {
+    font-size: 1.625rem;
+    line-height: 1.23;
+  }
+}
+@media (min-width: 600px) {
+  .content .layout-content h3, .font-size-heading-f3 {
+    font-size: 1.875rem;
+    line-height: 1.2;
+  }
+}
+@media (min-width: 900px) {
+  .content .layout-content h3, .font-size-heading-f3 {
+    font-size: 2rem;
+    line-height: 1.125;
+  }
+}
+@media (min-width: 1200px) {
+  .content .layout-content h3, .font-size-heading-f3 {
+    font-size: 2.188rem;
+    line-height: 1.143;
+  }
+}
+
+.content .layout-content h4, .font-size-heading-f4 {
+  font-weight: 600;
+}
+@media (max-width: 599px) {
+  .content .layout-content h4, .font-size-heading-f4 {
+    font-size: 1.375rem;
+    line-height: 1.244;
+  }
+}
+@media (min-width: 600px) {
+  .content .layout-content h4, .font-size-heading-f4 {
+    font-size: 1.563rem;
+    line-height: 1.28;
+  }
+}
+@media (min-width: 900px) {
+  .content .layout-content h4, .font-size-heading-f4 {
+    font-size: 1.625rem;
+    line-height: 1.230769231;
+  }
+}
+@media (min-width: 1200px) {
+  .content .layout-content h4, .font-size-heading-f4 {
+    font-size: 1.75rem;
+    line-height: 1.143;
+  }
+}
+
+.content .layout-content h5, .font-size-heading-f5 {
+  font-weight: 600;
+}
+@media (max-width: 599px) {
+  .content .layout-content h5, .font-size-heading-f5 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+}
+@media (min-width: 600px) {
+  .content .layout-content h5, .font-size-heading-f5 {
+    font-size: 1.313rem;
+    line-height: 1.143;
+  }
+}
+@media (min-width: 900px) {
+  .content .layout-content h5, .font-size-heading-f5 {
+    font-size: 1.375rem;
+    line-height: 1.273;
+  }
+}
+@media (min-width: 1200px) {
+  .content .layout-content h5, .font-size-heading-f5 {
+    font-size: 1.375rem;
+    line-height: 1.244;
+  }
+}
+
+.content .layout-content .font-size-display-large, .font-size-display-large {
+  font-weight: 700;
+}
+@media (max-width: 599px) {
+  .content .layout-content .font-size-display-large, .font-size-display-large {
+    font-size: 2.875rem;
+    line-height: 0.957;
+  }
+}
+@media (min-width: 600px) {
+  .content .layout-content .font-size-display-large, .font-size-display-large {
+    font-size: 4.438rem;
+    line-height: 1.01;
+  }
+}
+@media (min-width: 900px) {
+  .content .layout-content .font-size-display-large, .font-size-display-large {
+    font-size: 5.563rem;
+    line-height: 0.989;
+  }
+}
+@media (min-width: 1200px) {
+  .content .layout-content .font-size-display-large, .font-size-display-large {
+    font-size: 6.688rem;
+    line-height: 0.972;
+  }
+}
+
+.content .layout-content .font-size-display-small, .font-size-display-small {
+  font-weight: 700;
+}
+@media (max-width: 599px) {
+  .content .layout-content .font-size-display-small, .font-size-display-small {
+    font-size: 2.563rem;
+    line-height: 0.976;
+  }
+}
+@media (min-width: 600px) {
+  .content .layout-content .font-size-display-small, .font-size-display-small {
+    font-size: 2.938rem;
+    line-height: 1.021;
+  }
+}
+@media (min-width: 900px) {
+  .content .layout-content .font-size-display-small, .font-size-display-small {
+    font-size: 4.5rem;
+    line-height: 1;
+  }
+}
+@media (min-width: 1200px) {
+  .content .layout-content .font-size-display-small, .font-size-display-small {
+    font-size: 5.375rem;
+    line-height: 1.023;
+  }
+}
+
+.font-size-long-form-sans-serif {
+  font-size: 1.063rem;
+  line-height: 1.647;
+}
+@media (min-width: 900px) {
+  .font-size-long-form-sans-serif {
+    font-size: 1.25rem;
+    line-height: 1.5;
+  }
+}
+
+.font-size-long-form-serif {
+  font-size: 1.063rem;
+  line-height: 1.647;
+  font-family: "Source Serif Pro", Georgia, Cambria, "Times New Roman", Times, serif;
+}
+@media (min-width: 900px) {
+  .font-size-long-form-serif {
+    font-size: 1.25rem;
+    line-height: 1.5;
+  }
+}
+
+@media (max-width: 599px) {
+  .font-size-paragraph-large {
+    font-size: 1.25rem;
+    line-height: 1.379;
+  }
+}
+@media (min-width: 600px) {
+  .font-size-paragraph-large {
+    font-size: 1.438rem;
+    line-height: 1.362;
+  }
+}
+@media (min-width: 900px) {
+  .font-size-paragraph-large {
+    font-size: 1.563rem;
+    line-height: 1.412;
+  }
+}
+@media (min-width: 1200px) {
+  .font-size-paragraph-large {
+    font-size: 1.75rem;
+    line-height: 1.286;
+  }
+}
+
+.content .layout-content p, .font-size-paragraph-base {
+  font-size: 1.125rem;
+  line-height: 1.556;
+}
+
+.f-navigation-primary.nav-wrapper .adt-nav-text, .font-size-paragraph-base-semi-bold {
+  font-size: 1.125rem;
+  line-height: 1.556;
+  font-weight: 600;
+}
+
+.font-size-paragraph-small {
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.font-size-paragraph-xsmall {
+  font-size: 0.9em;
+  line-height: 1.389;
+}
+
+.font-size-paragraph-tiny {
+  font-size: 0.688rem;
+  line-height: 1.391;
+}
+
+.font-size-small-caps {
+  font-size: 0.9rem;
+  line-height: 1.389;
+  font-weight: 600;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+body .content h5,
+body .content .font-spec-5, body .content h4,
+body .content .font-spec-4, body .content h3,
+body .content .font-spec-3, body .content h2,
+body .content .font-spec-2, body .content h1,
+body .content .font-spec-1 {
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+body .content .small-caps, body .content p.superfine-print, body .content p.large, body .content h5,
+body .content .font-spec-5, body .content h4,
+body .content .font-spec-4, body .content h3,
+body .content .font-spec-3, body .content h2,
+body .content .font-spec-2, body .content h1,
+body .content .font-spec-1, body .content p.fine-print {
+  margin: 0 0 16px;
+}
+
+body .content p.fine-print {
+  font-size: 1em;
+}
+
+body .content h1,
+body .content .font-spec-1 {
+  font-size: 3em;
+  line-height: 1.05;
+}
+@media (min-width: 768px) and (max-width: 979px) {
+  body .content h1,
+  body .content .font-spec-1 {
+    font-size: 2.5em;
+  }
+}
+@media (max-width: 767px) {
+  body .content h1,
+  body .content .font-spec-1 {
+    font-size: 2em;
+  }
+}
+
+body .content h2,
+body .content .font-spec-2 {
+  font-size: 2.25em;
+}
+@media (min-width: 768px) and (max-width: 979px) {
+  body .content h2,
+  body .content .font-spec-2 {
+    font-size: 2em;
+  }
+}
+@media (max-width: 767px) {
+  body .content h2,
+  body .content .font-spec-2 {
+    font-size: 1.625em;
+  }
+}
+
+body .content h3,
+body .content .font-spec-3 {
+  font-size: 1.75em;
+}
+@media (min-width: 768px) and (max-width: 979px) {
+  body .content h3,
+  body .content .font-spec-3 {
+    font-size: 1.5em;
+  }
+}
+@media (max-width: 767px) {
+  body .content h3,
+  body .content .font-spec-3 {
+    font-size: 1.375em;
+  }
+}
+
+body .content h4,
+body .content .font-spec-4 {
+  font-size: 1.125em;
+}
+
+body .content h5,
+body .content .font-spec-5 {
+  font-size: 1em;
+}
+
+body .content p.large {
+  font-size: 1.75em;
+  line-height: 1.25em;
+}
+@media (min-width: 768px) and (max-width: 979px) {
+  body .content p.large {
+    font-size: 1.5em;
+  }
+}
+@media (max-width: 767px) {
+  body .content p.large {
+    font-size: 1.375em;
+  }
+}
+
+body .content p.superfine-print {
+  font-size: 0.85714em;
+}
+
+body .content .small-caps {
+  font-size: 0.833125em;
+  font-weight: 400;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+@font-face {
+  font-family: "Source Code Pro";
+  font-style: normal;
+  font-weight: 200;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-200.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-200.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-200.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-200.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-200.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-200.svg#Source_Code_Pro") format("svg");
+}
+@font-face {
+  font-family: "Source Code Pro";
+  font-style: normal;
+  font-weight: 300;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-300.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-300.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-300.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-300.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-300.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-300.svg#Source_Code_Pro") format("svg");
+}
+@font-face {
+  font-family: "Source Code Pro";
+  font-style: normal;
+  font-weight: 400;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-400.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-400.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-400.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-400.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-400.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-400.svg#Source_Code_Pro") format("svg");
+}
+@font-face {
+  font-family: "Source Code Pro";
+  font-style: italic;
+  font-weight: 400;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-italic.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-italic.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-italic.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-italic.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-italic.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-italic.svg#Source_Code_Pro") format("svg");
+}
+@font-face {
+  font-family: "Source Code Pro";
+  font-style: normal;
+  font-weight: 600;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-600.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-600.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-600.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-600.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-600.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-600.svg#Source_Code_Pro") format("svg");
+}
+@font-face {
+  font-family: "Source Code Pro";
+  font-style: normal;
+  font-weight: 700;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-700.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-700.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-700.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-700.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-700.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-code-pro-v21-vietnamese_latin_cyrillic-700.svg#Source_Code_Pro") format("svg");
+}
+@font-face {
+  font-family: "Source Sans Pro";
+  font-style: normal;
+  font-weight: 200;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-200.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-200.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-200.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-200.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-200.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-200.svg#Source_Sans_Pro") format("svg");
+}
+@font-face {
+  font-family: "Source Sans Pro";
+  font-style: normal;
+  font-weight: 300;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-300.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-300.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-300.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-300.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-300.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-300.svg#Source_Sans_Pro") format("svg");
+}
+@font-face {
+  font-family: "Source Sans Pro";
+  font-style: normal;
+  font-weight: 400;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-400.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-400.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-400.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-400.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-400.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-400.svg#Source_Sans_Pro") format("svg");
+}
+@font-face {
+  font-family: "Source Sans Pro";
+  font-style: italic;
+  font-weight: 400;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-italic.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-italic.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-italic.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-italic.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-italic.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-italic.svg#Source_Sans_Pro") format("svg");
+}
+@font-face {
+  font-family: "Source Sans Pro";
+  font-style: normal;
+  font-weight: 600;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-600.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-600.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-600.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-600.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-600.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-600.svg#Source_Sans_Pro") format("svg");
+}
+@font-face {
+  font-family: "Source Sans Pro";
+  font-style: normal;
+  font-weight: 700;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-700.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-700.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-700.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-700.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-700.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/source-sans-pro-v21-vietnamese_latin_cyrillic-700.svg#Source_Sans_Pro") format("svg");
+}
+@font-face {
+  font-family: "Noto Sans SC";
+  font-style: normal;
+  font-weight: 200;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-200.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-200.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-200.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-200.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-200.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-200.svg#Noto_Sans_SC") format("svg");
+}
+@font-face {
+  font-family: "Noto Sans SC";
+  font-style: normal;
+  font-weight: 300;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-300.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-300.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-300.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-300.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-300.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-300.svg#Noto_Sans_SC") format("svg");
+}
+@font-face {
+  font-family: "Noto Sans SC";
+  font-style: normal;
+  font-weight: 400;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-400.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-400.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-400.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-400.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-400.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-400.svg#Noto_Sans_SC") format("svg");
+}
+@font-face {
+  font-family: "Noto Sans SC";
+  font-style: normal;
+  font-weight: 500;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-500.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-500.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-500.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-500.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-500.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-500.svg#Noto_Sans_SC") format("svg");
+}
+@font-face {
+  font-family: "Noto Sans SC";
+  font-style: normal;
+  font-weight: 700;
+  src: url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-700.eot");
+  src: local(""), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-700.eot?#iefix") format("embedded-opentype"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-700.woff2") format("woff2"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-700.woff") format("woff"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-700.ttf") format("truetype"), url("/o/osb-www-foundations-theme-contributor/fonts/noto-sans-sc-v26-latin_chinese-simplified-700.svg#Noto_Sans_SC") format("svg");
+}
+body .content {
+  font: 400 16px/1.5 "Source Sans Pro", Tahoma, "Trebuchet MS", sans-serif;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  position: relative;
+  right: 0;
+}
+body .content b,
+body .content strong {
+  font-weight: 700;
+}
+body .content blockquote {
+  font-size: 1.25em;
+  line-height: 1.25;
+}
+@media (max-width: 979px) {
+  body .content blockquote {
+    font-size: 1.5em;
+    line-height: 1.5;
+  }
+}
+body .content .long-form {
+  font-size: 1.25em;
+  line-height: 1.5;
+}
+body .content .long-form a:not(.btn) {
+  text-decoration: underline;
+}
+body .content .long-form h2 {
+  font-size: 1.5em;
+  font-weight: 400;
+  margin-top: 1em;
+}
+body .content .long-form h2:first-child {
+  margin-top: 0.25em;
+}
+body .content .long-form h3 {
+  font-size: 1.25em;
+  font-weight: 600;
+  margin-top: 1em;
+}
+body .content .long-form h4 {
+  font-size: 1.2em;
+  margin-top: 1em;
+}
+body .content .long-form li {
+  line-height: inherit;
+  margin-bottom: 1em;
+}
+body .content .long-form ol,
+body .content .long-form p:not(.small-caps),
+body .content .long-form ul {
+  font-family: "Source Serif Pro", Georgia, Cambria, "Times New Roman", Times, serif;
+  font-weight: 400;
+  margin-bottom: 1em;
+}
+body .content .long-form p.introduction {
+  font-size: 1.2em;
+}
+body .content .long-form ul:not(.unstyled) {
+  list-style: none;
+}
+body .content .long-form ul:not(.unstyled) li:before {
+  background-color: var(--neutral-5);
+  border-radius: 0.25em;
+  content: "";
+  display: inline-block;
+  height: 0.25em;
+  margin: 0 0.5em 0.25em -1em;
+  width: 0.25em;
+}
+body .content .long-form .long-form-title {
+  margin-bottom: calc(2em + 4px);
+  position: relative;
+}
+body .content .long-form .long-form-title:after {
+  background: #134194;
+  bottom: -1em;
+  content: "";
+  display: block;
+  height: 4px;
+  position: absolute;
+  width: 56px;
+}
+@media (min-width: 768px) and (max-width: 979px) {
+  body .content .long-form h2 {
+    font-size: 1.4em;
+  }
+  body .content .long-form h3 {
+    font-size: 1.2em;
+  }
+}
+@media (max-width: 767px) {
+  body .content .long-form {
+    font-size: 1.1em;
+    line-height: 1.6em;
+  }
+  body .content .long-form h2 {
+    font-size: 1.2em;
+    font-weight: 600;
+  }
+  body .content .long-form h3 {
+    font-size: 1.125em;
+  }
+}
+body .content .page-heading .preheading,
+body .content .preheading {
+  font-size: 1em;
+}
+body .content .subheading {
+  color: var(--neutral-5);
+  font-weight: 400;
+}
+body .content .source-text {
+  color: var(--neutral-5);
+  font-size: 0.75em;
+  margin: 0.5em 0;
+}
+
+.aspect-ratio-item-flush-110 {
+  max-width: none;
+  position: absolute;
+  width: 110%;
+}
+
+.aspect-ratio-item-flush-120 {
+  max-width: none;
+  position: absolute;
+  width: 120%;
+}
+
+.aspect-ratio-item-flush-130 {
+  max-width: none;
+  position: absolute;
+  width: 130%;
+}
+
+.aspect-ratio-item-vertical-flush-110 {
+  height: 110%;
+  max-height: none;
+  position: absolute;
+}
+
+.aspect-ratio-item-vertical-flush-120 {
+  height: 120%;
+  max-height: none;
+  position: absolute;
+}
+
+.aspect-ratio-item-vertical-flush-130 {
+  height: 130%;
+  max-height: none;
+  position: absolute;
+}
+
+.aspect-ratio-object-fit-cover {
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+.aspect-ratio-object-fit-cover .fragments-image-div,
+.aspect-ratio-object-fit-cover .fragments-div,
+.aspect-ratio-object-fit-cover .fragments-editor__editable[type=image] {
+  height: 100%;
+  position: absolute;
+  width: 100%;
+}
+.aspect-ratio-object-fit-cover .fragments-image-div img,
+.aspect-ratio-object-fit-cover .fragments-div img,
+.aspect-ratio-object-fit-cover .fragments-editor__editable[type=image] img {
+  height: 100%;
+  left: 0;
+  -o-object-fit: cover;
+     object-fit: cover;
+  position: absolute;
+  width: 100%;
+}
+
+.osb-svg--monospaced {
+  height: 100%;
+  width: 100%;
+}
+.osb-svg--monospaced .fragments-div,
+.osb-svg--monospaced .fragments-editor__editable[type=html] {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  text-align: center;
+  width: 100%;
+  word-wrap: break-word;
+}
+.osb-svg--monospaced .fragments-div svg,
+.osb-svg--monospaced .fragments-editor__editable[type=html] svg {
+  height: auto;
+  width: 100%;
+}
+.osb-svg--monospaced .html-placeholder {
+  background-color: #a7a9bc;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  position: relative;
+  width: 100%;
+}
+.osb-svg--monospaced .html-placeholder-text {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+@media (max-width: 599px) {
+  .hide-phone {
+    display: none !important;
+  }
+}
+
+@media (min-width: 600px) and (max-width: 899px) {
+  .hide-tablet-portrait {
+    display: none !important;
+  }
+}
+
+@media (min-width: 900px) and (max-width: 1199px) {
+  .hide-tablet-landscape {
+    display: none !important;
+  }
+}
+
+@media (min-width: 1200px) and (max-width: 1799px) {
+  .hide-desktop {
+    display: none !important;
+  }
+}
+
+@media (min-width: 1800px) {
+  .hide-large-desktop-up {
+    display: none !important;
+  }
+}
+
+.hover-text-decoration-none:hover {
+  text-decoration: none;
+}
+
+.content .align-center {
+  align-items: center;
+}
+.content .align-start {
+  align-items: flex-start;
+}
+.content .align-content-center {
+  align-content: center;
+}
+.content .block-container {
+  box-sizing: border-box;
+  display: flex;
+  flex-wrap: wrap;
+  padding: 1em;
+}
+.content .block-container .block {
+  box-sizing: border-box;
+}
+.content .block-container .block.preview-block {
+  padding: 0.5em;
+  width: 25%;
+}
+.content .block-container .block.preview-block a {
+  border: 1px solid;
+  border-radius: 4px;
+  display: block;
+  text-decoration: none;
+}
+@media (min-width: 768px) and (max-width: 979px) {
+  .content .block-container .block.preview-block {
+    width: 33.333%;
+  }
+}
+.content .block-container .block.right-block {
+  padding-left: 1em;
+}
+@media (max-width: 767px) {
+  .content .block-container .block {
+    width: 100% !important;
+  }
+}
+.content .border-bottom {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+}
+.content .border-left {
+  border-left-style: solid;
+  border-left-width: 1px;
+}
+.content .border-right {
+  border-right-style: solid;
+  border-right-width: 1px;
+}
+.content .border-top {
+  border-top-style: solid;
+  border-top-width: 1px;
+}
+.content .flex {
+  display: flex;
+}
+.content .flex-column {
+  flex-direction: column;
+}
+.content .flex-column-reverse {
+  flex-direction: column-reverse;
+}
+.content .flex-row {
+  flex-direction: row;
+}
+.content .flex-row-reverse {
+  flex-direction: row-reverse;
+}
+.content .font-weight-lighter {
+  font-weight: 200;
+}
+.content .font-weight-bold {
+  font-weight: 600;
+}
+.content .full-screen {
+  max-width: none !important;
+}
+.content .full-screen .portlet-column {
+  max-width: none;
+}
+.content .justify-center {
+  justify-content: center;
+}
+.content .justify-end {
+  justify-content: flex-end;
+}
+.content .justify-space-around {
+  justify-content: space-around;
+}
+.content .justify-space-between {
+  justify-content: space-between;
+}
+.content .justify-start {
+  justify-content: flex-start;
+}
+.content .max-full,
+.content .max-lg,
+.content .max-med,
+.content .max-sm {
+  box-sizing: border-box;
+  margin: 0 auto;
+  padding: 0 1em;
+}
+.content .max-full {
+  max-width: 1200px;
+}
+.content .max-lg {
+  max-width: 960px;
+}
+.content .max-med {
+  max-width: 720px;
+}
+.content .max-sm {
+  max-width: 480px;
+}
+.content .no-padding {
+  padding: 0;
+}
+.content .no-padding-horizontal {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+.content .no-padding-vertical {
+  padding-bottom: 0 !important;
+  padding-top: 0 !important;
+}
+.content .small-padding {
+  padding: 0.5em;
+}
+.content .small-padding-horizontal {
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+}
+.content .small-padding-vertical {
+  padding-bottom: 0.5em;
+  padding-top: 0.5em;
+}
+.content .standard-padding {
+  padding: 1em;
+}
+.content .standard-padding-horizontal {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+.content .standard-padding-vertical {
+  padding-bottom: 1em;
+  padding-top: 1em;
+}
+
+body.dark,
+.dark body {
+  background-image: linear-gradient(95.92deg, var(--primary-dark) 20.61%, var(--primary) 100%);
+}
+body.dark .page-editor__layout-viewport,
+body.dark .page-editor__layout-viewport__resizer,
+.dark body .page-editor__layout-viewport,
+.dark body .page-editor__layout-viewport__resizer {
+  background-color: transparent;
+}
+
+.dark {
+  color: var(--white);
+}
+
+.light {
+  color: var(--black);
+}
+
+.content .layout-content {
+  font: 400 16px/1.5 "Source Sans Pro", Tahoma, "Trebuchet MS", sans-serif;
+}
+.content .layout-content *,
+.content .layout-content *::before,
+.content .layout-content *::after {
+  box-sizing: border-box !important;
+}
+@media (min-width: 600px) {
+  .content .layout-content .text-center-tablet-portrait-up {
+    text-align: center;
+  }
+}
+
+.content .layout-content .fragments-editor-sidebar-section__title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 32px 0 24px 0;
+}
+
+.fragments-editor__editable[type=text],
+.fragments-editor__editable[type=rich-text] {
+  max-width: 100%;
+  word-wrap: break-word;
+}
+
+.zh_CN .content .layout-content {
+  font-family: "Source Sans Pro", "Noto Sans SC", Tahoma, "Trebuchet MS", sans-serif;
+}
+
+.bg-gradient-blue-purple {
+  background: linear-gradient(90deg, #0160f6 0.46%, #720bde 100%);
+}
+
+.bg-gradient-blue-red {
+  background: linear-gradient(45deg, #0160f6 0%, #f60c56 100%);
+}
+
+.bg-gradient-purple-blue {
+  background: linear-gradient(180deg, #710cdf 0%, #2446ef 1102.08%);
+}
+
+.portlet {
+  margin-bottom: 0;
+}
+
+.osb-icon {
+  fill: currentColor;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.osb-icon--scale {
+  height: 1.5em;
+  width: 1.5em;
+}
+
+.osb-icon--content-edge {
+  padding: 6px;
+}
+
+.osb-inline-link {
+  color: var(--action-default);
+  font-size: 18px;
+}
+.osb-inline-link:visited {
+  color: var(--action-visited);
+}
+.osb-inline-link:hover {
+  color: var(--action-default-hover);
+}
+.osb-inline-link:focus, .osb-inline-link.osb-btn--focus {
+  color: var(--action-default-hover);
+}
+.osb-inline-link:active, .osb-inline-link.osb-btn--active {
+  color: var(--action-default-active);
+}
+.osb-inline-link:disabled, .osb-inline-link.osb-btn--disabled {
+  color: var(--action-default);
+}
+.osb-inline-link--secondary {
+  color: var(--neutral-5);
+  font-size: 18px;
+  text-decoration: underline;
+}
+.osb-inline-link--secondary:visited {
+  color: var(--neutral-5);
+}
+.osb-inline-link--secondary:hover {
+  color: var(--neutral-5);
+}
+.osb-inline-link--secondary:focus, .osb-inline-link--secondary.osb-btn--focus {
+  color: var(--neutral-5);
+}
+.osb-inline-link--secondary:active, .osb-inline-link--secondary.osb-btn--active {
+  color: var(--neutral-5);
+}
+.osb-inline-link--secondary:disabled, .osb-inline-link--secondary.osb-btn--disabled {
+  color: var(--neutral-5);
+}
+.osb-inline-link--light {
+  color: rgba(var(--white), 0.7);
+}
+.osb-inline-link--light:visited {
+  color: rgba(var(--white), 0.7);
+}
+.osb-inline-link--light:hover {
+  color: rgba(var(--white), 0.7);
+}
+.osb-inline-link--light:focus, .osb-inline-link--light.osb-btn--focus {
+  color: rgba(var(--white), 0.7);
+}
+.osb-inline-link--light:active, .osb-inline-link--light.osb-btn--active {
+  color: rgba(var(--white), 0.7);
+}
+.osb-inline-link--light:disabled, .osb-inline-link--light.osb-btn--disabled {
+  color: rgba(var(--white), 0.7);
+}
+.osb-inline-link--underline {
+  text-decoration: underline;
+}
+.osb-inline-link--underline:hover {
+  text-decoration: none;
+}
+.osb-return-link {
+  align-items: center;
+  background-color: transparent;
+  border-width: 0;
+  color: var(--neutral-5);
+  display: inline-flex;
+  font-size: 0.9rem;
+  line-height: 27px;
+  max-width: 100%;
+  padding: 0;
+  text-decoration: none;
+  word-wrap: break-word;
+}
+.osb-return-link:visited {
+  color: var(--neutral-5);
+}
+.osb-return-link:hover {
+  color: var(--neutral-3);
+  text-decoration: none;
+}
+.osb-return-link:focus, .osb-return-link.osb-btn--focus {
+  color: var(--neutral-3);
+}
+.osb-return-link:active, .osb-return-link.osb-btn--active {
+  color: var(--black);
+}
+.osb-return-link:disabled, .osb-return-link.osb-btn--disabled {
+  background-color: transparent;
+  color: var(--neutral-5);
+}
+.osb-return-link > div {
+  display: inline;
+}
+.osb-return-link > svg {
+  flex-shrink: 0;
+  width: 1.5em;
+}
+
+.osb-cta {
+  align-items: center;
+  background-color: transparent;
+  border-width: 0;
+  color: var(--action-default);
+  display: inline-flex;
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 27px;
+  max-width: 100%;
+  text-decoration: none;
+  word-wrap: break-word;
+}
+.osb-cta:visited {
+  color: var(--action-visited);
+}
+.osb-cta:hover {
+  color: var(--action-default-hover);
+  text-decoration: none;
+}
+.osb-cta:focus, .osb-cta.osb-btn--focus {
+  color: var(--action-default-hover);
+}
+.osb-cta:active, .osb-cta.osb-btn--active {
+  color: var(--action-default-active);
+}
+.osb-cta:disabled, .osb-cta.osb-btn--disabled {
+  background-color: transparent;
+  color: var(--action-default);
+}
+.osb-cta > div {
+  display: inline;
+}
+.osb-cta > svg {
+  flex-shrink: 0;
+  margin-top: 3px;
+}
+.osb-cta .osb-icon--content-edge.osb-icon--scale {
+  margin-left: -4px;
+  padding: 7px;
+}
+
+.osb-cta--animate:hover > svg:first-child {
+  transform: translateX(-0.25rem);
+}
+.osb-cta--animate:hover > svg:last-child {
+  transform: translateX(0.25rem);
+}
+.osb-cta--animate > svg {
+  transition: transform 0.5s ease;
+}
+
+.osb-cta--large {
+  font-size: 1.5rem;
+  line-height: 36px;
+}
+.osb-cta--large .osb-icon--content-edge.osb-icon--scale {
+  margin-left: -5px;
+  padding: 11px;
+}
+
+.osb-cta--light,
+.dark .osb-cta {
+  color: var(--white);
+}
+.osb-cta--light:visited,
+.dark .osb-cta:visited {
+  color: var(--white);
+}
+.osb-cta--light:hover,
+.dark .osb-cta:hover {
+  color: var(--white);
+}
+.osb-cta--light:focus, .osb-cta--light.osb-btn--focus,
+.dark .osb-cta:focus,
+.dark .osb-cta.osb-btn--focus {
+  color: var(--white);
+}
+.osb-cta--light:active, .osb-cta--light.osb-btn--active,
+.dark .osb-cta:active,
+.dark .osb-cta.osb-btn--active {
+  color: var(--white);
+}
+.osb-cta--light:disabled, .osb-cta--light.osb-btn--disabled,
+.dark .osb-cta:disabled,
+.dark .osb-cta.osb-btn--disabled {
+  color: var(--white);
+}
+.osb-btn {
+  background-color: transparent;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 4px;
+  box-shadow: 0px 0.8px 3.7px -0.33px rgba(0, 0, 0, 0.14), 0px 2px 3px 0.15px rgba(0, 0, 0, 0.034), 0px 2.6px 4px -0.2px rgba(0, 0, 0, 0.06);
+  color: var(--black);
+  cursor: pointer;
+  display: inline-block;
+  font-size: 1em;
+  font-weight: 600;
+  line-height: 1;
+  margin: 0.25em 0 0.375em;
+  max-width: 100%;
+  padding-bottom: 0.6875rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.6875rem;
+  text-align: center;
+  transition: all 0.2s ease-in-out;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+  vertical-align: middle;
+  word-wrap: break-word;
+  z-index: 1;
+}
+.osb-btn:visited {
+  color: var(--black);
+}
+.osb-btn:hover {
+  box-shadow: 0px 1.1px 4.05px -0.66px rgba(0, 0, 0, 0.14), 0px 3px 4.5px 0.3px rgba(0, 0, 0, 0.036), 0px 2.9px 6px 0.2px rgba(0, 0, 0, 0.06);
+  color: var(--black);
+  text-decoration: none;
+  transform: translateY(calc(-3px - 1%));
+  transition: all 0.2s;
+}
+.osb-btn:focus, .osb-btn.osb-btn--focus {
+  box-shadow: 0 5px 11px -5px #000;
+  color: var(--black);
+  outline: 0;
+  transform: translateY(calc(-3px - 1%));
+  transition: all 0.2s;
+}
+.osb-btn:active, .osb-btn.osb-btn--active {
+  box-shadow: 0 5px 8px -5px rgba(0, 0, 0, 0.5);
+  color: var(--black);
+  transform: translateY(0);
+  transition: all 0.1s;
+}
+.osb-btn:disabled, .osb-btn.osb-btn--disabled {
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: 0px 0.8px 3.7px -0.33px rgba(0, 0, 0, 0.14), 0px 2px 3px 0.15px rgba(0, 0, 0, 0.034), 0px 2.6px 4px -0.2px rgba(0, 0, 0, 0.06);
+  color: var(--black);
+  cursor: not-allowed;
+  opacity: 0.5;
+  transform: none;
+}
+.osb-btn:disabled:active, .osb-btn.osb-btn--disabled:active {
+  pointer-events: none;
+}
+
+.osb-btn--icon-start {
+  padding-left: 2.5rem;
+  position: relative;
+}
+.osb-btn--icon-start svg {
+  height: 1.5em;
+  left: 0.6875rem;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-48%);
+  width: 1.5em;
+}
+
+.osb-btn--icon-end {
+  padding-right: 2.5rem;
+  position: relative;
+}
+.osb-btn--icon-end svg {
+  height: 1.5em;
+  position: absolute;
+  right: 0.6875rem;
+  top: 50%;
+  transform: translateY(-48%);
+  width: 1.5em;
+}
+
+.osb-btn--large {
+  font-size: 1.125em;
+  padding-bottom: 0.875rem;
+  padding-left: 1.1875rem;
+  padding-right: 1.1875rem;
+  padding-top: 0.875rem;
+}
+.osb-btn--large.osb-btn--icon-start {
+  padding-left: 2.75rem;
+}
+.osb-btn--large.osb-btn--icon-start svg {
+  left: 0.75rem;
+}
+.osb-btn--large.osb-btn--icon-end {
+  padding-right: 2.75rem;
+}
+.osb-btn--large.osb-btn--icon-end svg {
+  right: 0.75rem;
+}
+
+.osb-btn--small {
+  font-size: 0.875em;
+  margin: 0.5rem auto;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.5rem;
+}
+@media (min-width: 900px) {
+  .osb-btn--small {
+    margin: 0;
+  }
+}
+.osb-btn--small.osb-btn--icon-start {
+  padding-left: 1.75rem;
+}
+.osb-btn--small.osb-btn--icon-start svg {
+  left: 0.25rem;
+}
+.osb-btn--small.osb-btn--icon-end {
+  padding-right: 1.75rem;
+}
+.osb-btn--small.osb-btn--icon-end svg {
+  right: 0.25rem;
+}
+
+.osb-btn--block {
+  display: block;
+  width: 100%;
+}
+
+.osb-btn--monospaced {
+  align-items: center;
+  box-shadow: none;
+  display: inline-flex;
+  height: 2.5rem;
+  justify-content: center;
+  line-height: 1;
+  padding: 0;
+  transform: none;
+  width: 2.5rem;
+}
+.osb-btn--monospaced:hover {
+  box-shadow: none;
+  transform: none;
+}
+.osb-btn--monospaced:focus, .osb-btn--monospaced.osb-btn--focus {
+  box-shadow: none;
+  transform: none;
+}
+.osb-btn--monospaced:disabled, .osb-btn--monospaced.osb-btn--disabled {
+  box-shadow: none;
+}
+.osb-btn--monospaced.osb-btn--large {
+  height: 3rem;
+  width: 3rem;
+}
+.osb-btn--monospaced.osb-btn--small {
+  height: 2rem;
+  width: 2rem;
+}
+.osb-btn--flat {
+  margin-bottom: 0;
+  margin-top: 0;
+  transition: none;
+}
+.osb-btn--flat:hover {
+  transform: none;
+}
+.osb-btn--flat:focus, .osb-btn--flat.osb-btn--focus {
+  transform: none;
+}
+.osb-btn--flat:active, .osb-btn--flat.osb-btn--active {
+  transform: none;
+  transition: none;
+}
+.osb-btn--primary {
+  background-color: var(--action-default);
+  border-color: var(--action-default);
+  color: var(--white);
+}
+.osb-btn--primary:visited {
+  color: var(--white);
+}
+.osb-btn--primary:hover {
+  background-color: var(--action-default-hover);
+  border-color: var(--action-default-hover);
+  color: var(--white);
+}
+.osb-btn--primary:focus, .osb-btn--primary.osb-btn--focus {
+  background-color: var(--action-default-hover);
+  border-color: var(--action-default-hover);
+  color: var(--white);
+}
+.osb-btn--primary:active, .osb-btn--primary.osb-btn--active {
+  background-color: var(--action-default-active);
+  border-color: var(--action-default-active);
+  color: var(--white);
+}
+.osb-btn--primary:disabled, .osb-btn--primary.osb-btn--disabled {
+  background-color: var(--action-default);
+  border-color: var(--action-default);
+  color: var(--white);
+}
+.osb-btn--secondary {
+  background-color: var(--white);
+  border-color: var(--white);
+  color: var(--action-default);
+}
+.osb-btn--secondary:visited {
+  color: var(--action-default);
+}
+.osb-btn--secondary:hover {
+  color: var(--action-default-hover);
+}
+.osb-btn--secondary:focus, .osb-btn--secondary.osb-btn--focus {
+  color: var(--action-default-hover);
+}
+.osb-btn--secondary:active, .osb-btn--secondary.osb-btn--active {
+  color: var(--action-default-active);
+}
+.osb-btn--secondary:disabled, .osb-btn--secondary.osb-btn--disabled {
+  background-color: var(--white);
+  border-color: var(--white);
+  color: var(--action-default);
+}
+.osb-btn--alternate {
+  background-color: var(--accent-6);
+  border-color: var(--accent-6);
+  color: var(--white);
+}
+.osb-btn--alternate:visited {
+  color: var(--white);
+}
+.osb-btn--alternate:hover {
+  background-color: #169545;
+  border-color: #169545;
+  color: var(--white);
+}
+.osb-btn--alternate:focus, .osb-btn--alternate.osb-btn--focus {
+  background-color: #169545;
+  border-color: #169545;
+  color: var(--white);
+}
+.osb-btn--alternate:active, .osb-btn--alternate.osb-btn--active {
+  background-color: #127f3a;
+  border-color: #127f3a;
+  color: var(--white);
+}
+.osb-btn--alternate:disabled, .osb-btn--alternate.osb-btn--disabled {
+  background-color: var(--accent-6);
+  border-color: var(--accent-6);
+  color: var(--white);
+}
+.osb-btn--plaintext {
+  background-color: transparent;
+  box-shadow: none;
+  color: var(--action-default);
+  cursor: default;
+  display: inline-block;
+  font-size: 1.125rem;
+  font-weight: 600;
+  max-width: 100%;
+  padding: 0.625rem 0.5rem;
+  word-wrap: break-word;
+}
+.osb-btn--plaintext:visited {
+  color: var(--action-default);
+}
+.osb-btn--plaintext:hover {
+  box-shadow: none;
+  color: var(--action-default);
+}
+.osb-btn--plaintext:focus, .osb-btn--plaintext.osb-btn--focus {
+  box-shadow: none;
+  color: var(--action-default);
+}
+.osb-btn--plaintext:active, .osb-btn--plaintext.osb-btn--active {
+  color: var(--action-default);
+}
+.osb-btn--plaintext:disabled, .osb-btn--plaintext.osb-btn--disabled {
+  background-color: transparent;
+  box-shadow: none;
+  color: var(--action-default);
+}
+.osb-btn--plaintext.osb-btn--icon-start {
+  padding-left: 2rem;
+}
+.osb-btn--plaintext.osb-btn--icon-start > svg {
+  left: 3px;
+  margin-top: 0;
+}
+.osb-btn--plaintext.osb-btn--icon-end {
+  padding-right: 2rem;
+}
+.osb-btn--plaintext.osb-btn--icon-end > svg {
+  margin-top: 0;
+  right: 3px;
+}
+.osb-btn--plaintext.osb-btn--small {
+  padding-bottom: 0.375rem;
+  padding-top: 0.375rem;
+}
+.osb-btn--plaintext.osb-btn--large {
+  font-size: 1.5rem;
+  line-height: 36px;
+  padding-bottom: 0.34375rem;
+  padding-top: 0.34375rem;
+}
+.osb-btn--plaintext.osb-btn--large.osb-btn--icon-start {
+  padding-left: 2.5rem;
+}
+.osb-btn--plaintext.osb-btn--large.osb-btn--icon-start > svg {
+  left: 1px;
+}
+.osb-btn--plaintext.osb-btn--large.osb-btn--icon-end {
+  padding-right: 2.5rem;
+}
+.osb-btn--plaintext.osb-btn--large.osb-btn--icon-end > svg {
+  right: 1px;
+}
+
+.osb-card {
+  box-shadow: 0px 0.8px 3.7px -0.33px rgba(0, 0, 0, 0.14), 0px 2px 3px 0.15px rgba(0, 0, 0, 0.034), 0px 2.6px 4px -0.2px rgba(0, 0, 0, 0.06);
+  cursor: pointer;
+  color: var(--black);
+  margin-bottom: 0;
+  text-decoration: none;
+  transition: all 0.2s ease-in-out;
+}
+.osb-card:hover {
+  background-color: var(--white);
+  box-shadow: 0px 1.1px 4.05px -0.66px rgba(0, 0, 0, 0.14), 0px 3px 4.5px 0.3px rgba(0, 0, 0, 0.036), 0px 2.9px 6px 0.2px rgba(0, 0, 0, 0.06);
+  color: var(--action-default-hover);
+  text-decoration: none;
+  transform: translateY(calc(-3px - 1%));
+  transition: all 0.2s;
+}
+
+body.mobile-tablet-nav-visible {
+  overflow: hidden;
+}
+
+@media (min-width: 1200px) {
+  body.nav-dropdown-menu-overflow {
+    overflow: hidden;
+  }
+  body.nav-dropdown-menu-overflow.has-alert-container .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu .adt-submenu-outer-wrapper .adt-submenu-inner-wrapper {
+    margin-bottom: 4rem;
+  }
+  body.nav-dropdown-menu-overflow .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu .adt-submenu-outer-wrapper .adt-submenu-inner-wrapper {
+    margin-bottom: 3rem;
+  }
+}
+.has-alert-container.fill-banner .f-navigation-primary.nav-wrapper {
+  position: fixed;
+}
+.has-alert-container .f-navigation-primary.nav-wrapper {
+  position: absolute;
+  top: 48px;
+}
+
+.fill-banner .f-navigation-primary.nav-wrapper {
+  box-shadow: 0px 7.4px 11.4px -7.59px rgba(0, 0, 0, 0.14), 0px 24px 36px 3.45px rgba(0, 0, 0, 0.078), 0px 9.2px 48px 8.6px rgba(0, 0, 0, 0.06);
+  top: 0;
+}
+
+.has-control-menu .f-navigation-primary.nav-wrapper {
+  top: 56px;
+}
+@media (max-width: 576px) {
+  .has-control-menu .f-navigation-primary.nav-wrapper {
+    top: 48px;
+  }
+}
+.has-control-menu.has-alert-container.fill-banner .f-navigation-primary.nav-wrapper {
+  top: 56px;
+}
+.has-control-menu.has-alert-container .f-navigation-primary.nav-wrapper {
+  top: 48px;
+}
+.has-control-menu.has-edit-mode-menu.has-alert-container.fill-banner .f-navigation-primary.nav-wrapper,
+.has-control-menu.has-edit-mode-menu.has-alert-container .f-navigation-primary.nav-wrapper,
+.has-control-menu.has-edit-mode-menu.has-alert-container .f-navigation-primary.nav-wrapper .search-wrapper.search-open {
+  position: fixed;
+  top: calc(56px + 65px);
+}
+.has-control-menu.has-edit-mode-menu .f-navigation-primary {
+  top: calc(56px + 65px);
+}
+
+.product-menu-open .f-navigation-primary.nav-wrapper {
+  left: 320px;
+}
+
+.f-navigation-primary-padding {
+  padding-top: 64px;
+}
+.f-navigation-primary-padding.utility-navigation-padding {
+  padding-top: 112px;
+}
+@media (max-width: 599px) {
+  .f-navigation-primary-padding.utility-navigation-padding {
+    padding-top: 64px;
+  }
+}
+
+@media (min-width: 1200px) {
+  .f-navigation-primary.dark-theme.nav-wrapper .nav {
+    background-color: var(--primary-dark);
+  }
+  .f-navigation-primary.dark-theme.nav-wrapper .nav .primary-nav .content-wrapper .nav-items-wrapper,
+  .f-navigation-primary.dark-theme.nav-wrapper .nav .primary-nav .content-wrapper .liferay-logo:hover {
+    background-color: transparent;
+  }
+  .f-navigation-primary.dark-theme.nav-wrapper .nav .primary-nav .content-wrapper .nav-items-wrapper .adt-nav-item .adt-nav-text::after {
+    background: var(--white);
+  }
+  .f-navigation-primary.dark-theme.nav-wrapper .adt-nav-text {
+    background-color: transparent;
+    color: white;
+  }
+  .f-navigation-primary.dark-theme.nav-wrapper .adt-nav-text:hover, .f-navigation-primary.dark-theme.nav-wrapper .adt-nav-text:focus {
+    background-color: var(--white);
+  }
+}
+@media (min-width: 600px) and (max-width: 1199px) {
+  .f-navigation-primary.dark-theme.nav-wrapper .mobile-buttons .mobile-menu {
+    border-color: var(--white);
+    color: var(--white);
+  }
+  .f-navigation-primary.dark-theme.nav-wrapper .primary-nav {
+    background-color: var(--primary-dark);
+  }
+  .f-navigation-primary.dark-theme.nav-wrapper .utility-nav {
+    display: none;
+  }
+}
+@media (max-width: 599px) {
+  .f-navigation-primary.dark-theme.nav-wrapper .utility-nav {
+    background-color: var(--primary-dark);
+    border-bottom-color: transparent;
+  }
+  .f-navigation-primary.dark-theme.nav-wrapper .utility-nav .content-wrapper .utility-nav-right .search-button {
+    display: none;
+  }
+  .f-navigation-primary.dark-theme.nav-wrapper .utility-nav .content-wrapper .dropdown .utility-nav-link.language-selector {
+    color: var(--white);
+    opacity: 1;
+  }
+  .f-navigation-primary.dark-theme.nav-wrapper .utility-nav .content-wrapper .dropdown .utility-nav-link.language-selector svg {
+    fill: var(--white);
+  }
+}
+
+.f-navigation-primary.nav-wrapper {
+  bottom: auto;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  transition: box-shadow 0.3s ease;
+  will-change: box-shadow;
+  z-index: 980;
+}
+.f-navigation-primary.nav-wrapper.search-open {
+  z-index: 982;
+}
+.f-navigation-primary.nav-wrapper .nav {
+  background-color: var(--white);
+}
+.f-navigation-primary.nav-wrapper * {
+  box-sizing: border-box;
+}
+.f-navigation-primary.nav-wrapper .utility-nav .liferay-logo {
+  display: none;
+}
+.f-navigation-primary.nav-wrapper .adt-navigation {
+  display: flex;
+  flex-wrap: inherit;
+  list-style: none;
+  margin-bottom: 0;
+  padding-left: 0;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item {
+  outline: 0px solid transparent;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item:focus .adt-nav-text {
+  background-color: #ebf2ff;
+  color: var(--action-default-hover);
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-nav-text:focus {
+  outline: none;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item.dropdown-open .adt-angle-down-svg {
+  transform: translate3d(0px, 0px, 0px) scale3d(1, 1, 1) rotateX(180deg) rotateY(0deg) rotateZ(0deg) skew(0deg, 0deg);
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item.dropdown-open .adt-nav-text {
+  background-color: #ebf2ff;
+  border-radius: 4px;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item.dropdown-open .adt-nav-text .adt-nav-title {
+  color: var(--action-default-active);
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item.dropdown-open .adt-submenu {
+  margin: 0;
+  opacity: 1;
+  transform: translateY(0);
+  visibility: visible;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu {
+  background-clip: padding-box;
+  background-color: #fff;
+  border-color: #e7e7ed;
+  border-style: solid;
+  border-width: 0;
+  display: block;
+  float: left;
+  left: 0;
+  list-style: none;
+  margin: 0.3125rem 0 0;
+  max-height: 80vh;
+  max-width: none;
+  min-height: auto;
+  opacity: 0;
+  overflow: auto;
+  padding: 1rem 4rem 4.5rem 4rem;
+  position: absolute;
+  right: 0;
+  transform: translateY(-100px);
+  transition: transform 0.3s cubic-bezier(0.23, 1, 0.32, 1), opacity 0.1s linear, visibility 0.3s linear;
+  visibility: hidden;
+  z-index: -1;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu .adt-submenu-outer-wrapper {
+  width: 100%;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu .adt-submenu-outer-wrapper .adt-submenu-inner-wrapper {
+  display: -ms-grid;
+  display: grid;
+  grid-column-gap: 4rem;
+  grid-row-gap: 2.5rem;
+  -ms-grid-columns: 1fr 4rem 1fr 4rem 1fr 4rem 1fr 4rem 1fr 4rem 1fr 4rem 1fr 4rem 1fr 4rem 1fr 4rem 1fr 4rem 1fr 4rem 1fr;
+  grid-template-columns: repeat(12, 1fr);
+  margin: 0 auto;
+  max-width: 1240px;
+  width: 100%;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-header {
+  border-bottom: 1px solid var(--neutral-7);
+  -ms-grid-row: span 1;
+  grid-row-end: span 1;
+  -ms-grid-row-span: 1;
+  grid-row-start: span 1;
+  list-style: none;
+  margin-bottom: -1rem;
+  padding-bottom: 0.5rem;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-item-content {
+  display: flex;
+  list-style: none;
+  max-width: 274px;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-item-content.image-type {
+  max-width: none;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-item-content .adt-submenu-item-link {
+  display: flex;
+  transition: box-shadow 0.1s linear, background-color 0.1s linear;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-item-content .adt-submenu-item-link:hover, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-item-content .adt-submenu-item-link:focus {
+  background-color: #ebf2ff;
+  border-radius: 0.5px;
+  box-shadow: 0 0 0 8px #ebf2ff;
+  outline: none;
+  text-decoration: none;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-item-content .adt-submenu-item-link:hover .adt-submenu-item-title, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-item-content .adt-submenu-item-link:focus .adt-submenu-item-title {
+  color: var(--action-default-hover);
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-item-content .adt-submenu-item-link .adt-submenu-item-title {
+  padding-bottom: 0.5rem;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-item-image {
+  border-radius: 4px;
+  height: 94px;
+  margin-right: 1rem;
+  -o-object-fit: cover;
+     object-fit: cover;
+  width: 94px;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-item-preheader {
+  font-size: 0.9rem;
+  letter-spacing: 0.1em;
+  line-height: 1.25rem;
+  padding-bottom: 0.5rem;
+  text-transform: uppercase;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section {
+  align-items: start;
+  -webkit-box-align: start;
+  display: -ms-grid;
+  display: grid;
+  -ms-flex-align: start;
+  grid-auto-columns: 1fr;
+  grid-auto-rows: -webkit-min-content;
+  grid-auto-rows: min-content;
+  grid-column-gap: 4rem;
+  grid-row-gap: 2.5rem;
+  list-style: none;
+  padding: 2rem 0;
+  width: 100%;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section.light-blue {
+  background-color: var(--primary-5);
+  border-radius: 8px;
+  padding: 2rem;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._3-section-span {
+  -ms-grid-column-span: 3;
+  -ms-grid-column: span 3;
+      grid-column-start: span 3;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._3-section-span .adt-submenu-header {
+  -ms-grid-column-span: 3;
+  -ms-grid-column: span 3;
+      grid-column-start: span 3;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._4-section-span {
+  -ms-grid-column-span: 4;
+  -ms-grid-column: span 4;
+      grid-column-start: span 4;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._4-section-span .adt-submenu-header {
+  -ms-grid-column-span: 4;
+  -ms-grid-column: span 4;
+      grid-column-start: span 4;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._5-section-span {
+  -ms-grid-column-span: 5;
+  -ms-grid-column: span 5;
+      grid-column-start: span 5;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._5-section-span .adt-submenu-header {
+  -ms-grid-column: 2/span 5;
+  -ms-grid-column-span: 5;
+  -ms-grid-column: span 5;
+      grid-column-start: span 5;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._6-section-span {
+  -ms-grid-column-span: 6;
+  -ms-grid-column: span 6;
+      grid-column-start: span 6;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._6-section-span .adt-submenu-header {
+  -ms-grid-column: 2/span 6;
+  -ms-grid-column-span: 6;
+  -ms-grid-column: span 6;
+      grid-column-start: span 6;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._7-section-span {
+  -ms-grid-column-span: 7;
+  -ms-grid-column: span 7;
+      grid-column-start: span 7;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._7-section-span .adt-submenu-header {
+  -ms-grid-column: 2/span 7;
+  -ms-grid-column-span: 7;
+  -ms-grid-column: span 7;
+      grid-column-start: span 7;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._8-section-span {
+  -ms-grid-column-span: 8;
+  -ms-grid-column: span 8;
+      grid-column-start: span 8;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._8-section-span .adt-submenu-header {
+  -ms-grid-column: 2/span 8;
+  -ms-grid-column-span: 8;
+  -ms-grid-column: span 8;
+      grid-column-start: span 8;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._9-section-span {
+  -ms-grid-column-span: 9;
+  -ms-grid-column: span 9;
+      grid-column-start: span 9;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._9-section-span .adt-submenu-header {
+  -ms-grid-column: 2/span 9;
+  -ms-grid-column-span: 9;
+  -ms-grid-column: span 9;
+      grid-column-start: span 9;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._10-section-span {
+  -ms-grid-column-span: 10;
+  -ms-grid-column: span 10;
+      grid-column-start: span 10;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._10-section-span .adt-submenu-header {
+  -ms-grid-column: 2/span 10;
+  -ms-grid-column-span: 10;
+  -ms-grid-column: span 10;
+      grid-column-start: span 10;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._11-section-span {
+  -ms-grid-column-span: 11;
+  -ms-grid-column: span 11;
+      grid-column-start: span 11;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._11-section-span .adt-submenu-header {
+  -ms-grid-column: 2/span 11;
+  -ms-grid-column-span: 11;
+  -ms-grid-column: span 11;
+      grid-column-start: span 11;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._12-section-span {
+  -ms-grid-column-span: 12;
+  -ms-grid-column: span 12;
+      grid-column-start: span 12;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._12-section-span .adt-submenu-header {
+  -ms-grid-column: 2/span 12;
+  -ms-grid-column-span: 12;
+  -ms-grid-column: span 12;
+      grid-column-start: span 12;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-1 {
+  -ms-grid-column: span 1;
+      grid-column-start: span 1;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-2 {
+  -ms-grid-column: span 2;
+      grid-column-start: span 2;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-3 {
+  -ms-grid-column: span 3;
+      grid-column-start: span 3;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-4 {
+  -ms-grid-column: span 4;
+      grid-column-start: span 4;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-5 {
+  -ms-grid-column: span 5;
+      grid-column-start: span 5;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-6 {
+  -ms-grid-column: span 6;
+      grid-column-start: span 6;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-7 {
+  -ms-grid-column: span 7;
+      grid-column-start: span 7;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-8 {
+  -ms-grid-column: span 8;
+      grid-column-start: span 8;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-9 {
+  -ms-grid-column: span 9;
+      grid-column-start: span 9;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-10 {
+  -ms-grid-column: span 10;
+      grid-column-start: span 10;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-11 {
+  -ms-grid-column: span 11;
+      grid-column-start: span 11;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-12 {
+  -ms-grid-column: span 12;
+      grid-column-start: span 12;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-text {
+  background-color: var(--white);
+  color: var(--neutral-2);
+  font-weight: 600;
+  position: relative;
+  text-decoration: none;
+  transition-duration: 0.2s, 0.2s;
+  transition-property: color, background-color;
+  transition-timing-function: ease, ease;
+}
+.f-navigation-primary.nav-wrapper .adt-nav-text:hover, .f-navigation-primary.nav-wrapper .adt-nav-text:focus {
+  background-color: #ebf2ff;
+  color: var(--action-default-hover);
+}
+.f-navigation-primary.nav-wrapper .nav-items-wrapper .adt-nav-item,
+.f-navigation-primary.nav-wrapper .nav-items-wrapper .portlet {
+  position: static;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper.search-open {
+  min-height: 80vh;
+  opacity: 1;
+  transform: translate3d(0px, 0px, 0px);
+  z-index: 2;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper {
+  align-items: center;
+  background-color: var(--accent-10);
+  border-radius: 0 0 8px 8px;
+  bottom: auto;
+  box-shadow: 0px 1.1px 4.05px -0.66px rgba(0, 0, 0, 0.14), 0px 3px 4.5px 0.3px rgba(0, 0, 0, 0.036), 0px 2.9px 6px 0.2px rgba(0, 0, 0, 0.06);
+  display: flex;
+  flex-direction: column;
+  left: 0;
+  opacity: 0;
+  padding: 3.5rem;
+  position: fixed;
+  right: 0;
+  top: 0;
+  transform: translate3d(0px, -800px, 0px);
+  transform-style: preserve-3d;
+  transition: transform 0.25s, opacity 0.25s;
+  z-index: -2;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper form.search {
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 4px;
+  margin-bottom: 0;
+  margin-left: auto;
+  margin-right: auto;
+  position: relative;
+  width: 30rem;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper form.search input.search-input {
+  background-color: transparent;
+  border: 0 none #000;
+  color: var(--white);
+  font-size: 28px;
+  font-weight: 600;
+  height: 3.5rem;
+  line-height: 32px;
+  margin-bottom: 0;
+  outline: none;
+  padding: 0.5rem 0.75rem;
+  width: 100%;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper form.search input.search-input::-moz-placeholder {
+  color: rgba(var(--white), 0.4);
+  opacity: 1;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper form.search input.search-input:-ms-input-placeholder {
+  color: rgba(var(--white), 0.4);
+  opacity: 1;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper form.search input.search-input::placeholder {
+  color: rgba(var(--white), 0.4);
+  opacity: 1;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper form.search input[type=search]::-ms-clear {
+  display: none;
+  height: 0;
+  width: 0;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper form.search input[type=search]::-ms-reveal {
+  display: none;
+  height: 0;
+  width: 0;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper form.search input[type=search]::-webkit-search-decoration,
+.f-navigation-primary.nav-wrapper .search-wrapper form.search input[type=search]::-webkit-search-cancel-button,
+.f-navigation-primary.nav-wrapper .search-wrapper form.search input[type=search]::-webkit-search-results-button,
+.f-navigation-primary.nav-wrapper .search-wrapper form.search input[type=search]::-webkit-search-results-decoration {
+  display: none;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper form.search .search-submit {
+  -webkit-appearance: none;
+  position: absolute;
+  right: 0.5rem;
+  top: 0.25rem;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper form.search .search-submit svg {
+  background-color: #142d5b;
+  height: 3rem;
+  stroke: var(--white);
+  width: 3rem;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions {
+  padding-top: 3.875rem;
+  width: 30rem;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .st-nav-results-container .search-result em {
+  font-style: normal;
+  font-weight: 900;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .st-nav-results-container .st-loading-message {
+  color: var(--white);
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .results-header {
+  align-items: center;
+  -webkit-box-align: center;
+  -webkit-box-pack: justify;
+  display: flex;
+  -ms-flex-align: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .results-header a:hover {
+  color: var(--white);
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .results-header .popular,
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .results-header .suggested {
+  color: rgba(255, 255, 255, 0.7);
+  font-weight: 600;
+  letter-spacing: 0.1rem;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .results-header .all-results-link {
+  color: var(--white);
+  font-size: 1rem;
+  line-height: 24px;
+  opacity: 0.7;
+  text-decoration: none;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .suggestion-links {
+  -webkit-box-pack: justify;
+  display: flex;
+  justify-content: space-between;
+  width: 31rem;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .suggestion-links .utility-nav-link {
+  align-items: center;
+  border-radius: 4px;
+  -webkit-box-align: center;
+  color: var(--accent-10);
+  display: flex;
+  -ms-flex-align: center;
+  font-weight: 600;
+  line-height: 20px;
+  opacity: 0.7;
+  padding: 0.625rem;
+  text-decoration: none;
+  transition: background-color 0.2s ease, border-color 0.2s ease, opacity 0.2s ease;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .suggestion-links .utility-nav-link.search-recommendation {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0);
+  border-style: solid;
+  border-width: 1px;
+  color: var(--white);
+  margin-right: 1rem;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .suggestion-links .utility-nav-link.search-recommendation:hover {
+  border: 1px solid var(--white);
+  opacity: 1;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .search-results .search-result {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0);
+  border-radius: 8px;
+  border-style: solid;
+  border-width: 1px;
+  color: var(--white);
+  display: inline-block;
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  text-decoration: none;
+  transition: border-color 0.2s ease;
+  width: 100%;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .search-results .search-result:hover {
+  border-color: var(--white);
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .search-results .search-result .search-result-heading {
+  color: var(--white);
+  font-weight: 600;
+  line-height: 28px;
+  margin-bottom: 0;
+  margin-top: 0;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .search-results .search-result .search-result-url {
+  font-weight: 600;
+  line-height: 20px;
+  opacity: 0.8;
+  padding-top: 0.75rem;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .search-results .st-no-results,
+.f-navigation-primary.nav-wrapper .search-wrapper .suggestions .search-results .st-spelling-suggestion {
+  color: var(--white);
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .close-search {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0);
+  border-radius: 2px;
+  border-style: solid;
+  border-width: 1px;
+  bottom: auto;
+  display: flex;
+  height: 2rem;
+  left: auto;
+  padding: 0.5rem;
+  position: absolute;
+  right: 3.5rem;
+  top: 3.5rem;
+  width: 2rem;
+}
+.f-navigation-primary.nav-wrapper .search-wrapper .close-search:hover {
+  border: 1px solid var(--white);
+  opacity: 1;
+}
+.f-navigation-primary.nav-wrapper .skip-to-footer-wrapper {
+  background: var(--white);
+  border-radius: 4px;
+  box-shadow: 0px 1.1px 4.05px -0.66px rgba(0, 0, 0, 0.14), 0px 3px 4.5px 0.3px rgba(0, 0, 0, 0.036), 0px 2.9px 6px 0.2px rgba(0, 0, 0, 0.06);
+  left: -50%;
+  padding: 0.25rem 0.75rem;
+  position: absolute;
+  transform: translateX(-50%);
+}
+.f-navigation-primary.nav-wrapper .skip-to-footer-wrapper .skip-to-footer-text {
+  color: var(--action-default-active);
+  font-size: 19px;
+  font-weight: 600;
+  text-align: center;
+}
+.f-navigation-primary.nav-wrapper .skip-to-footer-wrapper:focus {
+  left: 50%;
+}
+.f-navigation-primary .utility-nav {
+  height: 3rem;
+  margin: 0 auto;
+  max-width: 1366px;
+  position: relative;
+  width: 100%;
+  z-index: 2;
+}
+.f-navigation-primary .utility-nav .content-wrapper {
+  height: 100%;
+  width: 100%;
+}
+.f-navigation-primary .utility-nav .content-wrapper.utility {
+  border-bottom: solid 1px #dadee3;
+}
+.f-navigation-primary .utility-nav .utility-nav-left .info-for {
+  color: var(--accent-10);
+  font-weight: 600;
+  opacity: 0.6;
+  padding-right: 0.5rem;
+  text-align: center;
+}
+.f-navigation-primary .utility-nav .utility-nav-left .utility-nav-link {
+  border-radius: 4px;
+  color: var(--accent-10);
+  display: inline-block;
+  font-weight: 600;
+  opacity: 0.7;
+  padding: 0.625rem;
+  text-decoration: none;
+  transition-duration: 0.2s, 0.2s, 0.2s;
+  transition-property: background-color, opacity, color;
+  transition-timing-function: ease, ease, ease;
+}
+.f-navigation-primary .utility-nav .utility-nav-left .utility-nav-link:hover {
+  background: #ebf2ff;
+  color: var(--action-default-active);
+  opacity: 1;
+}
+.f-navigation-primary .utility-nav .utility-nav-right {
+  margin-right: -0.5rem;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown {
+  margin-left: 1rem;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .language-dropdown-toggle {
+  color: #222;
+  cursor: pointer;
+  display: inline-block;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 1.5rem;
+  padding-right: 2.5rem;
+  position: relative;
+  text-align: left;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: top;
+  white-space: nowrap;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .utility-nav-link.language-selector svg {
+  fill: var(--accent-10);
+  height: 1rem;
+  margin-bottom: 0.0625rem;
+  margin-right: 0.25rem;
+  transition-duration: 0.2s;
+  transition-property: fill;
+  transition-timing-function: ease;
+  width: 1rem;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .utility-nav-link.language-selector:hover {
+  background-color: #ebf2ff;
+  color: var(--action-default-active);
+  opacity: 1;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .utility-nav-link.language-selector:hover svg {
+  fill: var(--action-default-active);
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .utility-nav-link {
+  align-items: center;
+  border-radius: 4px;
+  color: #000;
+  display: flex;
+  font-weight: 600;
+  opacity: 0.7;
+  padding: 0.625rem;
+  transition-duration: 0.2s, 0.2s, 0.2s;
+  transition-property: color, background-color, opacity;
+  transition-timing-function: ease, ease, ease;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper {
+  display: none;
+  position: absolute;
+  right: 0;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list {
+  background-color: var(--white);
+  border-radius: 4px;
+  box-shadow: rgba(0, 0, 0, 0.22) 0px 2px 6px 0px;
+  display: flex;
+  flex-direction: column;
+  padding: 0.5rem 0.25rem 0 0.25rem;
+  width: 12.5rem;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list ul {
+  -webkit-padding-start: 0;
+          padding-inline-start: 0;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item {
+  align-items: center;
+  border-radius: 4px;
+  display: flex;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  padding: 0.25rem 0.25rem 0.25rem 1.5rem;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item:active {
+  background-color: #ebf2ff;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item:focus {
+  background-color: #ebf2ff;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item:hover {
+  background-color: #ebf2ff;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item .language-entry-long-text {
+  color: var(--neutral-2);
+  width: 100%;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item .language-entry-long-text:active {
+  color: var(--neutral-2);
+  text-decoration: none;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item .language-entry-long-text:visited {
+  color: var(--neutral-2);
+  text-decoration: none;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item .language-entry-long-text:focus {
+  color: var(--neutral-2);
+  text-decoration: none;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item .language-entry-long-text:hover {
+  color: var(--neutral-2);
+  text-decoration: none;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item.selected {
+  padding-left: 0.4375rem;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item.selected .language-entry-long-text {
+  color: #004ad7;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .selected.osb-nav-item:before {
+  content: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2212%22%20height%3D%229%22%20viewBox%3D%220%200%2012%209%22%20fill%3D%22none%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%0A%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M9.62623%200.958909C10.0168%200.568385%2010.6499%200.568385%2011.0404%200.958909C11.431%201.34943%2011.431%201.9826%2011.0404%202.37312L5.04127%208.37229C5.04099%208.37257%205.04072%208.37285%205.04044%208.37312C4.64992%208.76365%204.01675%208.76365%203.62623%208.37312L0.292893%205.03979C-0.0976311%204.64927%20-0.0976311%204.0161%200.292893%203.62558C0.683417%203.23505%201.31658%203.23505%201.70711%203.62558L4.33333%206.2518L9.62623%200.958909Z%22%20fill%3D%22%23004AD7%22/%3E%0A%3C/svg%3E%0A");
+  margin-right: 0.3125rem;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .dropdown .dropdown-list-wrapper.list-open {
+  display: block;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .search-button {
+  border-radius: 4px;
+  display: inline-block;
+  margin-left: 0.5rem;
+  max-width: 100%;
+  opacity: 0.7;
+  position: relative;
+  transition-duration: 0.2s, 0.2s, 0.2s;
+  transition-property: opacity, background-color, stroke;
+  transition-timing-function: ease, ease, ease;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .search-button svg {
+  height: 2.5rem;
+  stroke: var(--accent-10);
+  transition-duration: 0.2s;
+  transition-property: stroke;
+  transition-timing-function: ease;
+  width: 2.5rem;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .search-button:hover {
+  background-color: #ebf2ff;
+  opacity: 1;
+}
+.f-navigation-primary .utility-nav .utility-nav-right .search-button:hover svg {
+  stroke: var(--action-default-active);
+}
+.f-navigation-primary .contact-sales,
+.f-navigation-primary .contact-sales-container .w-button {
+  background-color: var(--accent-6);
+  border-radius: 4px;
+  color: var(--white);
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5rem;
+  margin-left: 1rem;
+  padding: 0.5rem 1rem;
+  position: relative;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.f-navigation-primary .contact-sales:hover,
+.f-navigation-primary .contact-sales-container .w-button:hover {
+  background-color: var(--action-secondary-hover);
+}
+.f-navigation-primary .primary-nav {
+  height: 4rem;
+  margin: 0 auto;
+  max-width: 1366px;
+  padding: 0;
+  width: 100%;
+}
+.f-navigation-primary .primary-nav .content-wrapper {
+  height: 100%;
+  justify-content: space-between;
+  padding: 0 1.5rem;
+  width: 100%;
+}
+.f-navigation-primary .primary-nav .content-wrapper .liferay-logo {
+  border-radius: 4px;
+  width: 9.5rem;
+}
+.f-navigation-primary .primary-nav .content-wrapper .liferay-logo svg {
+  height: 3rem;
+  width: 100%;
+}
+.f-navigation-primary .primary-nav .content-wrapper .liferay-logo svg:last-child {
+  color: var(--black);
+}
+.f-navigation-primary .primary-nav .content-wrapper .liferay-logo:hover {
+  background-color: #ebf2ff;
+}
+@media screen and (max-width: 991px) {
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    left: 0;
+    overflow: scroll;
+    padding-bottom: 7.5rem;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transform: translate3d(0, -100%, 0) scale3d(1, 1, 1) rotateX(0deg) rotateY(0deg) rotateZ(0deg) skew(0deg, 0deg);
+    transform-style: preserve-3d;
+    z-index: -1;
+  }
+}
+.f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper {
+  align-items: stretch;
+  background-color: var(--white);
+  padding-top: 5rem;
+}
+.f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .underline-container {
+  display: none;
+}
+.f-navigation-primary .mobile-buttons {
+  bottom: 0.75rem;
+  padding: 0 1.5rem;
+}
+.f-navigation-primary .mobile-buttons .button-text-close {
+  display: none;
+}
+.f-navigation-primary .mobile-buttons .mobile-menu.menu-open .button-text-close {
+  display: block;
+}
+.f-navigation-primary .mobile-buttons .mobile-menu.menu-open .button-text-menu {
+  display: none;
+}
+@media (max-width: 599px) {
+  .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu {
+    box-shadow: none;
+    grid-row-gap: 0;
+    height: auto;
+    max-height: 0;
+    opacity: 1;
+    overflow: hidden;
+    padding: 0;
+    position: static;
+    transform: none;
+    transition: max-height 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+    visibility: visible;
+  }
+  .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu .adt-submenu-outer-wrapper .adt-submenu-inner-wrapper {
+    display: flex;
+    flex-direction: column;
+  }
+  .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu .adt-submenu-section {
+    display: flex;
+    flex-direction: column;
+    -ms-grid-rows: none;
+    grid-template-rows: none;
+    padding-left: 1.5rem;
+    padding-right: 2rem;
+  }
+  .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-header {
+    border-width: 0;
+    margin-bottom: 0;
+    padding-bottom: 1rem;
+  }
+  .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-item-content {
+    padding-bottom: 2.5rem;
+  }
+  .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-item-content:not(.image-type) {
+    border-left: solid 2px var(--neutral-7);
+    max-width: none;
+    padding-left: 1rem;
+  }
+  .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section {
+    display: none;
+    grid-row-gap: 0;
+  }
+  .f-navigation-primary .nav .search-wrapper.search-open {
+    height: 100vh;
+    overflow: auto;
+    padding: 5rem 1.5rem 1.5rem;
+    z-index: 4;
+  }
+  .f-navigation-primary .nav .search-wrapper.search-open .close-search {
+    right: 1.5rem;
+    top: 1rem;
+  }
+  .f-navigation-primary .nav .search-wrapper.search-open .search {
+    width: 100%;
+  }
+  .f-navigation-primary .nav .search-wrapper.search-open .search .search-input > .search-submit {
+    background-color: var(--accent-10);
+  }
+  .f-navigation-primary .nav .search-wrapper.search-open .suggestions {
+    width: 100%;
+  }
+  .f-navigation-primary .nav .search-wrapper.search-open .suggestions .suggestion-links {
+    justify-content: center;
+    width: 100%;
+  }
+}
+@media (max-width: 599px) and (max-width: 400px) {
+  .f-navigation-primary .nav .search-wrapper.search-open .suggestions .suggestion-links {
+    flex-wrap: wrap;
+    justify-content: space-between;
+    text-align: center;
+  }
+  .f-navigation-primary .nav .search-wrapper.search-open .suggestions .suggestion-links a:last-child {
+    margin-top: 1rem;
+  }
+  .f-navigation-primary .nav .search-wrapper.search-open .suggestions .suggestion-links a.utility-nav-link.search-recommendation {
+    justify-content: center;
+    margin-right: 0;
+    width: 30%;
+  }
+}
+@media (max-width: 599px) {
+  .f-navigation-primary .utility-nav {
+    background-color: var(--white);
+    border-bottom: 1px solid var(--neutral-8);
+    display: block;
+    height: 4rem;
+    padding: 0.75rem 1.5rem;
+    position: relative;
+    z-index: 3;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper {
+    height: 100%;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 1240px;
+    width: 100%;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper.utility {
+    border-width: 0;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .liferay-logo {
+    display: block;
+    width: 7.5rem;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .liferay-logo svg {
+    height: 3rem;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .liferay-logo svg:last-child {
+    color: var(--black);
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-left {
+    display: none;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right {
+    margin-right: -0.5rem;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown {
+    margin-left: 1rem;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .language-dropdown-toggle {
+    color: #222;
+    cursor: pointer;
+    display: inline-block;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 1.5rem;
+    padding-right: 2.5rem;
+    position: relative;
+    text-align: left;
+    text-decoration: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    vertical-align: top;
+    white-space: nowrap;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .utility-nav-link.language-selector svg {
+    fill: var(--accent-10);
+    height: 1rem;
+    margin-bottom: 0.0625rem;
+    margin-right: 0.25rem;
+    transition-duration: 200;
+    transition-property: fill;
+    transition-timing-function: ease;
+    width: 1rem;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .utility-nav-link.language-selector:hover {
+    background-color: #ebf2ff;
+    color: var(--action-default-active);
+    opacity: 1;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .utility-nav-link.language-selector:hover svg {
+    fill: var(--action-default-active);
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .utility-nav-link {
+    align-items: center;
+    border-radius: 4px;
+    color: #000;
+    display: flex;
+    font-weight: 600;
+    opacity: 0.7;
+    padding: 0.625rem;
+    transition-duration: 0.2s, 0.2s, 0.2s;
+    transition-property: color, background-color, opacity;
+    transition-timing-function: ease, ease, ease;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper {
+    display: none;
+    position: absolute;
+    right: 0;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list {
+    background-color: var(--white);
+    border-radius: 4px;
+    box-shadow: rgba(0, 0, 0, 0.22) 0px 2px 6px 0px;
+    display: flex;
+    flex-direction: column;
+    padding: 0.5rem 0.25rem 0 0.25rem;
+    width: 12.5rem;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list ul {
+    -webkit-padding-start: 0;
+            padding-inline-start: 0;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item {
+    align-items: center;
+    border-radius: 4px;
+    display: flex;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    padding: 0.25rem 0.25rem 0.25rem 1.5rem;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item:active {
+    background-color: #ebf2ff;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item:focus {
+    background-color: #ebf2ff;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item:hover {
+    background-color: #ebf2ff;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item .language-entry-long-text {
+    color: var(--neutral-2);
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item .language-entry-long-text:active {
+    color: var(--neutral-2);
+    text-decoration: none;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item .language-entry-long-text:visited {
+    color: var(--neutral-2);
+    text-decoration: none;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item .language-entry-long-text:focus {
+    color: var(--neutral-2);
+    text-decoration: none;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item .language-entry-long-text:hover {
+    color: var(--neutral-2);
+    text-decoration: none;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item.selected {
+    padding-left: 0.4375rem;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .osb-nav-item.selected .language-entry-long-text {
+    color: #004ad7;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper .dropdown-list .selected.osb-nav-item:before {
+    content: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2212%22%20height%3D%229%22%20viewBox%3D%220%200%2012%209%22%20fill%3D%22none%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%0A%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M9.62623%200.958909C10.0168%200.568385%2010.6499%200.568385%2011.0404%200.958909C11.431%201.34943%2011.431%201.9826%2011.0404%202.37312L5.04127%208.37229C5.04099%208.37257%205.04072%208.37285%205.04044%208.37312C4.64992%208.76365%204.01675%208.76365%203.62623%208.37312L0.292893%205.03979C-0.0976311%204.64927%20-0.0976311%204.0161%200.292893%203.62558C0.683417%203.23505%201.31658%203.23505%201.70711%203.62558L4.33333%206.2518L9.62623%200.958909Z%22%20fill%3D%22%23004AD7%22/%3E%0A%3C/svg%3E%0A");
+    margin-right: 0.3125rem;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .dropdown .dropdown-list-wrapper.list-open {
+    display: block;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .search-button {
+    border-radius: 4px;
+    display: inline-block;
+    margin-left: 0.5rem;
+    opacity: 0.7;
+    position: relative;
+    transition-duration: 0.2s, 0.2s, 0.2s;
+    transition-property: opacity, background-color, stroke;
+    transition-timing-function: ease, ease, ease;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .search-button svg {
+    height: 2.5rem;
+    stroke: var(--accent-10);
+    transition-duration: 0.2s;
+    transition-property: stroke;
+    transition-timing-function: ease;
+    width: 2.5rem;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .search-button:hover {
+    background-color: #ebf2ff;
+    opacity: 1;
+  }
+  .f-navigation-primary .utility-nav .content-wrapper .utility-nav-right .search-button:hover svg {
+    stroke: var(--action-default-active);
+  }
+}
+@media (max-width: 599px) {
+  .f-navigation-primary .primary-nav {
+    border: none;
+    height: 0;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper {
+    padding: 0 1.5rem;
+    position: relative;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .liferay-logo {
+    display: none;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper {
+    align-items: center;
+    background-color: transparent;
+    height: 0;
+    left: 0;
+    opacity: 0;
+    padding-bottom: 8.5rem;
+    padding-top: 0;
+    position: absolute;
+    top: 0;
+    transition: all 0.5s cubic-bezier(0.19, 1, 0.22, 1);
+    visibility: hidden;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper.menu-open {
+    background-color: var(--white);
+    height: 100vh;
+    opacity: 1;
+    overflow-x: hidden;
+    top: 0;
+    transform: translateY(0);
+    visibility: visible;
+    z-index: 2;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper.menu-open::after {
+    background-color: var(--white);
+    content: "";
+    height: 100vh;
+    width: 100vw;
+    z-index: -3;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .adt-navigation {
+    background: var(--white);
+    display: flex;
+    flex-direction: column;
+    overflow: visible;
+    width: 100vw;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .adt-navigation .adt-nav-text {
+    padding-bottom: 0.875rem;
+    padding-top: 0.875rem;
+    position: sticky;
+    position: -webkit-sticky;
+    top: 0;
+    width: 100%;
+    z-index: 3;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .adt-navigation .adt-nav-text .adt-nav-title {
+    padding-left: 1.5rem;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .adt-navigation .adt-angle-down-svg {
+    position: absolute;
+    right: 1.5rem;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .underline-container {
+    display: block;
+    padding: 0.375rem 1.5rem 0 1.5rem;
+    width: 100%;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .underline-container .underline {
+    border: 1px solid var(--neutral-7);
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .contact-sales-container {
+    display: flex;
+    padding: 0 1.5rem 10rem;
+    width: 100%;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .contact-sales-container .contact-sales {
+    box-shadow: 0px 1.1px 4.05px -0.66px rgba(0, 0, 0, 0.14), 0px 3px 4.5px 0.3px rgba(0, 0, 0, 0.036), 0px 2.9px 6px 0.2px rgba(0, 0, 0, 0.06);
+    margin: 0;
+    text-align: center;
+    width: 100%;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .utility-nav-left {
+    background-color: var(--white);
+    display: block;
+    padding: 1.5rem 1.5rem 2rem;
+    width: 100%;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .utility-nav-left .info-for {
+    display: flex;
+    font-weight: 600;
+    justify-content: space-between;
+    width: 100%;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .utility-nav-left .info-for > a {
+    color: var(--neutral-3);
+    font-size: 1rem;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .navbar-nav {
+    background: var(--white);
+    display: flex;
+    flex-direction: column;
+    width: 100vw;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .navbar-nav .nav-link {
+    padding-bottom: 0.875rem;
+    padding-top: 0.875rem;
+    width: 100%;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .navbar-nav .nav-link > span {
+    padding-left: 1rem;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .navbar-nav .lfr-nav-child-toggle {
+    position: absolute;
+    right: 1.5rem;
+  }
+}
+@media (max-width: 599px) {
+  .f-navigation-primary .mobile-buttons {
+    bottom: 0.75rem;
+    position: fixed;
+    right: 50%;
+    transform: translate(50%, 0);
+    z-index: 3;
+  }
+  .f-navigation-primary .mobile-buttons .contact-sales {
+    display: none;
+  }
+  .f-navigation-primary .mobile-buttons .mobile-menu {
+    background-color: var(--white);
+    border: 1px solid var(--action-default);
+    border-radius: 1.5rem;
+    box-shadow: 0px 1.1px 4.05px -0.66px rgba(0, 0, 0, 0.14), 0px 3px 4.5px 0.3px rgba(0, 0, 0, 0.036), 0px 2.9px 6px 0.2px rgba(0, 0, 0, 0.06);
+    color: var(--action-default);
+    display: block;
+    font-size: 1.125rem;
+    font-weight: 600;
+    padding: 0.5rem 1rem;
+    text-align: center;
+    text-decoration: none;
+    width: 7.5rem;
+  }
+}
+@media (min-width: 600px) and (max-width: 1199px) {
+  .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu {
+    box-shadow: none;
+    grid-row-gap: 0;
+    height: auto;
+    margin: 0;
+    max-height: 0;
+    opacity: 1;
+    padding: 0;
+    position: static;
+    transform: none;
+    transition: max-height 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+    visibility: visible;
+  }
+  .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu .adt-submenu-outer-wrapper .adt-submenu-inner-wrapper {
+    display: flex;
+    flex-direction: column;
+  }
+  .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section {
+    -ms-grid-rows: none;
+    grid-template-rows: none;
+    padding: 2rem;
+  }
+  .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-1, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-2, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-3, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-4, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-5, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-6, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-7, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-8, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-9, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-10, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-11, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section .adt-submenu-item-content.grid-column-span-12 {
+    -ms-grid-column: span 1;
+        grid-column-start: span 1;
+  }
+  .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._3-section-span, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._4-section-span, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._5-section-span, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._6-section-span, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._7-section-span, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._8-section-span, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._9-section-span, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._10-section-span, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._11-section-span, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._12-section-span {
+    -ms-grid-column-span: 2;
+    -ms-grid-column: span 2;
+        grid-column-start: span 2;
+  }
+  .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._3-section-span .adt-submenu-header, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._4-section-span .adt-submenu-header, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._5-section-span .adt-submenu-header, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._6-section-span .adt-submenu-header, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._7-section-span .adt-submenu-header, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._8-section-span .adt-submenu-header, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._9-section-span .adt-submenu-header, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._10-section-span .adt-submenu-header, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._11-section-span .adt-submenu-header, .f-navigation-primary.nav-wrapper .adt-nav-item .adt-submenu-section._12-section-span .adt-submenu-header {
+    -ms-grid-column-span: 2;
+    -ms-grid-column: span 2;
+        grid-column-start: span 2;
+  }
+  .f-navigation-primary .primary-nav {
+    padding: 0;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper {
+    padding-left: 1.5rem;
+    padding-right: 2rem;
+    position: relative;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .liferay-logo {
+    padding-left: 0.5rem;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .liferay-logo svg {
+    height: 3rem;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper {
+    align-items: center;
+    background-color: transparent;
+    height: 0;
+    left: 0;
+    opacity: 0;
+    padding-bottom: 0;
+    padding-top: 0;
+    position: absolute;
+    top: 0;
+    transition: all 0.5s cubic-bezier(0.19, 1, 0.22, 1);
+    visibility: hidden;
+    z-index: -1;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper.menu-open {
+    background-color: var(--white);
+    height: 100vh;
+    opacity: 1;
+    overflow: auto;
+    top: 4rem;
+    transform: translateY(0);
+    visibility: visible;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .contact-sales-container,
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .utility-nav-left {
+    display: none;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .adt-navigation {
+    background: var(--white);
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 120px - 4rem);
+    overflow: auto;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .adt-navigation .adt-nav-text {
+    padding: 0.875rem 1rem;
+    position: sticky;
+    position: -webkit-sticky;
+    top: 0;
+    width: 100%;
+    z-index: 3;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .adt-navigation .adt-nav-text .adt-nav-title {
+    padding-left: 1rem;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .adt-navigation .adt-angle-down-svg {
+    position: absolute;
+    right: 1.5rem;
+  }
+  .f-navigation-primary .mobile-buttons {
+    display: flex;
+    padding-right: 1.5rem;
+    position: absolute;
+    right: 0;
+    z-index: 1;
+  }
+  .f-navigation-primary .mobile-buttons .tablet {
+    display: inline-block;
+    margin-left: 0;
+    margin-right: 1rem;
+    top: auto;
+  }
+  .f-navigation-primary .mobile-buttons .mobile-menu {
+    border: 1px solid var(--action-default);
+    border-radius: 4px;
+    color: var(--action-default);
+    display: inline-block;
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 24px;
+    text-decoration: none;
+    z-index: 1;
+  }
+  .f-navigation-primary .mobile-buttons .mobile-menu .button-text-close {
+    padding: 0.5rem 1rem;
+  }
+  .f-navigation-primary .mobile-buttons .mobile-menu .button-text-menu {
+    padding: 0.5rem 1rem;
+  }
+  .f-navigation-primary .utility-nav {
+    padding: 0 2rem;
+  }
+}
+@media (min-width: 1200px) {
+  .f-navigation-primary .nav.show-border {
+    border-bottom: 1px solid var(--neutral-8);
+  }
+  .f-navigation-primary .nav .utility-nav .content-wrapper {
+    margin: 0 4rem;
+  }
+  .f-navigation-primary .primary-nav {
+    border-bottom: 1px solid transparent;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper {
+    margin: 0 4rem;
+    padding: 0;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .liferay-logo svg {
+    height: 3.37rem;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper {
+    align-items: center;
+    display: flex;
+    padding: 0;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .adt-nav-item.dropdown-open .adt-nav-text::after {
+    left: 0;
+    width: 100%;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .adt-nav-item .adt-nav-text {
+    border-radius: 4px;
+    padding: 0;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .adt-nav-item .adt-nav-text .adt-nav-title {
+    cursor: pointer;
+    font-size: 1.125rem;
+    padding: 0.875rem 1.125rem 0.688rem;
+    position: relative;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .adt-nav-item .adt-nav-text .adt-nav-title .adt-angle-down-svg {
+    display: none;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .adt-nav-item .adt-nav-text::after {
+    background: #004ad7;
+    bottom: -5px;
+    content: "";
+    height: 3px;
+    left: 50%;
+    position: absolute;
+    transition: left ease-in 0.3s, width ease-in 0.3s;
+    width: 0%;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .adt-nav-item .adt-submenu {
+    border-radius: 0 0 0.5rem 0.5rem;
+    box-shadow: 0px 7.4px 11.4px -7.59px rgba(0, 0, 0, 0.14), 0px 24px 36px 3.45px rgba(0, 0, 0, 0.078), 0px 9.2px 48px 8.6px rgba(0, 0, 0, 0.06);
+    padding-bottom: 1rem;
+  }
+  .f-navigation-primary .primary-nav .content-wrapper .nav-items-wrapper .utility-nav-left {
+    display: none;
+  }
+  .f-navigation-primary .mobile-buttons {
+    display: none;
+  }
+}
+
+#footer.f-navigation-footer {
+  background-color: var(--accent-10);
+  color: var(--white);
+  padding: 1em;
+}
+@media screen and (min-width: 767px) {
+  #footer.f-navigation-footer {
+    padding: 0 3em;
+  }
+}
+#footer.f-navigation-footer .max-nav {
+  margin: 0 auto;
+  max-width: 1240px;
+  padding: 3em 0 !important;
+}
+#footer.f-navigation-footer ul {
+  margin: 0;
+  padding: 0;
+}
+#footer.f-navigation-footer li {
+  line-height: 20px;
+  list-style: none;
+  margin: 0;
+}
+#footer.f-navigation-footer h4 {
+  color: var(--white);
+  line-height: 1.5em;
+  margin: 0;
+  padding: 1.5em 0;
+}
+#footer.f-navigation-footer a {
+  display: block;
+}
+#footer.f-navigation-footer a:hover {
+  text-decoration: none;
+}
+#footer.f-navigation-footer .footer-content {
+  flex-direction: column;
+  flex-wrap: nowrap;
+  padding: 1em 0;
+}
+@media screen and (min-width: 767px) {
+  #footer.f-navigation-footer .footer-content {
+    flex-direction: row;
+  }
+}
+#footer.f-navigation-footer .footer-content .footer-navigation {
+  flex: 5;
+}
+#footer.f-navigation-footer .footer-content .footer-navigation .language-wrapper {
+  box-sizing: border-box;
+  margin: 0;
+  padding-bottom: 1.5em;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+@media screen and (min-width: 767px) {
+  #footer.f-navigation-footer .footer-content .footer-navigation .language-wrapper {
+    margin-left: -2em;
+  }
+}
+#footer.f-navigation-footer .footer-content .footer-navigation .language-wrapper .languages .selected {
+  display: none;
+}
+#footer.f-navigation-footer .footer-content .footer-navigation .language-wrapper.class-toggle-active .dropdown-content {
+  height: auto;
+  opacity: 1;
+  overflow: visible;
+  padding: 0.5em;
+  visibility: visible;
+}
+#footer.f-navigation-footer .footer-content .footer-navigation .language-wrapper.class-toggle-active .dropdown-content a {
+  color: var(--black);
+  padding: 0.375em 0.75em;
+}
+#footer.f-navigation-footer .footer-content .footer-navigation .language-wrapper .dropdown-content {
+  background: var(--white);
+  border-radius: 0.25em;
+  box-shadow: 0px 1.1px 4.05px -0.66px rgba(0, 0, 0, 0.14), 0px 3px 4.5px 0.3px rgba(0, 0, 0, 0.036), 0px 2.9px 6px 0.2px rgba(0, 0, 0, 0.06);
+  box-sizing: border-box;
+  height: 0;
+  line-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  transform-origin: center top;
+  transition: opacity 0.25s cubic-bezier(0.77, 0, 0.175, 1), visibility 0.25s cubic-bezier(0.77, 0, 0.175, 1);
+  visibility: hidden;
+  white-space: nowrap;
+  z-index: 1000;
+}
+#footer.f-navigation-footer .footer-content .footer-navigation .language-wrapper .dropdown-content::after {
+  background: var(--white);
+  border-radius: 1.25em 0 0;
+  bottom: -7px;
+  content: "";
+  height: 14px;
+  left: 10%;
+  position: absolute;
+  transform: rotate(45deg);
+  transition: left 0.25s cubic-bezier(0.77, 0, 0.175, 1);
+  width: 14px;
+}
+#footer.f-navigation-footer .footer-content .footer-navigation .language-wrapper .dropdown-content.top {
+  bottom: calc(100% + 14px);
+}
+#footer.f-navigation-footer .footer-content .footer-navigation .language-wrapper .dropdown-content.right {
+  left: 0;
+}
+#footer.f-navigation-footer .footer-content .footer-navigation .language-wrapper .language-selector {
+  align-items: center;
+  -webkit-box-align: center;
+  cursor: pointer;
+  display: flex;
+  -ms-flex-align: center;
+}
+#footer.f-navigation-footer .footer-content .footer-navigation .language-wrapper .language-selector .current-language {
+  font-size: 1.15em;
+  font-weight: 600;
+  padding-left: 0.5em;
+}
+#footer.f-navigation-footer .footer-content .footer-navigation .navigation {
+  flex-wrap: wrap;
+}
+#footer.f-navigation-footer .footer-content .footer-navigation .navigation a {
+  color: var(--white);
+  font-weight: 600;
+  padding-bottom: 1em;
+}
+#footer.f-navigation-footer .footer-content .footer-navigation .navigation a:hover {
+  color: var(--neutral-5);
+}
+#footer.f-navigation-footer .footer-content .footer-navigation .navigation div {
+  box-sizing: border-box;
+  padding-right: 0;
+  width: 100%;
+}
+@media screen and (min-width: 767px) {
+  #footer.f-navigation-footer .footer-content .footer-navigation .navigation div {
+    width: initial;
+  }
+}
+@media (min-width: 900px) {
+  #footer.f-navigation-footer .footer-content .footer-navigation .navigation div {
+    padding-right: 4em;
+  }
+}
+@media (min-width: 768px) and (max-width: 979px) {
+  #footer.f-navigation-footer .footer-content .footer-navigation .navigation div {
+    padding-right: 3em;
+  }
+}
+#footer.f-navigation-footer .footer-content .footer-navigation .navigation div .nav-item-header {
+  font-size: 0.833125em;
+  font-weight: 400;
+  letter-spacing: 1px;
+  margin-bottom: 0;
+  text-transform: uppercase;
+}
+#footer.f-navigation-footer .footer-content .footer-liferay-connect {
+  flex: 1;
+  padding-top: 4em;
+}
+@media screen and (min-width: 767px) {
+  #footer.f-navigation-footer .footer-content .footer-liferay-connect {
+    padding-top: 0;
+  }
+}
+#footer.f-navigation-footer .footer-content .footer-liferay-connect .social-nav {
+  margin-left: -1em;
+  margin-right: -1em;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+}
+@media screen and (min-width: 767px) {
+  #footer.f-navigation-footer .footer-content .footer-liferay-connect .social-nav {
+    margin-left: 0;
+  }
+}
+#footer.f-navigation-footer .footer-content .footer-liferay-connect .social-nav a {
+  color: var(--white);
+  height: 3.25em;
+}
+#footer.f-navigation-footer .footer-content .footer-liferay-connect .social-nav svg {
+  display: inline-block;
+  fill: var(--white);
+  height: 1.25em;
+  margin: 0.5em;
+  transition: all 0.25s ease-in-out;
+  width: 1.25em;
+}
+#footer.f-navigation-footer .footer-content .footer-liferay-connect .contact-info {
+  color: var(--white);
+  text-align: left;
+}
+@media screen and (min-width: 767px) {
+  #footer.f-navigation-footer .footer-content .footer-liferay-connect .contact-info {
+    text-align: right;
+  }
+}
+#footer.f-navigation-footer .footer-content .footer-liferay-connect .contact-info a {
+  color: var(--white);
+  cursor: pointer;
+  line-height: 1.5em;
+  margin: 0;
+  padding: 1.5em 0;
+}
+#footer.f-navigation-footer .footer-content .footer-liferay-connect .contact-info p {
+  font-size: 1.125em;
+}
+#footer.f-navigation-footer .fine-print {
+  background-color: var(--accent-10);
+  box-sizing: border-box;
+  color: var(--neutral-7);
+  display: flex;
+  flex-wrap: wrap;
+  padding: 2em 0 5em;
+  text-align: left;
+}
+#footer.f-navigation-footer .fine-print a {
+  color: var(--neutral-7);
+  font-size: 0.9em;
+  width: 100%;
+}
+@media screen and (min-width: 767px) {
+  #footer.f-navigation-footer .fine-print a {
+    width: initial;
+  }
+}
+#footer.f-navigation-footer .fine-print a:hover {
+  color: var(--black);
+}
+#footer.f-navigation-footer .fine-print p {
+  font-size: 0.9em;
+  width: 100%;
+}
+@media screen and (min-width: 767px) {
+  #footer.f-navigation-footer .fine-print p {
+    width: initial;
+  }
+}
+
+html:not(#__):not(#___) body .page-editor__layout-viewport--size-tablet,
+html:not(#__):not(#___) body .page-editor__layout-viewport--size-landscapeMobile,
+html:not(#__):not(#___) body .page-editor__layout-viewport--size-portraitMobile {
+  height: 100vh;
+}
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm9zYi1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci5jc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7RUFDRSxvQkFBb0I7QUFDdEI7O0FBRUE7RUFDRSwrQkFBK0I7QUFDakM7O0FBRUE7RUFDRSxtQkFBbUI7QUFDckI7O0FBRUE7RUFDRSw4QkFBOEI7QUFDaEM7O0FBRUE7RUFDRSxxQkFBcUI7QUFDdkI7O0FBRUE7RUFDRSxnQ0FBZ0M7QUFDbEM7O0FBRUE7RUFDRSx3QkFBd0I7QUFDMUI7O0FBRUE7RUFDRSxtQ0FBbUM7QUFDckM7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSxrQ0FBa0M7QUFDcEM7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSxrQ0FBa0M7QUFDcEM7O0FBRUE7RUFDRSwwQkFBMEI7QUFDNUI7O0FBRUE7RUFDRSxxQ0FBcUM7QUFDdkM7O0FBRUE7RUFDRSxtQkFBbUI7QUFDckI7O0FBRUE7RUFDRSw4QkFBOEI7QUFDaEM7O0FBRUE7RUFDRSxzQkFBc0I7QUFDeEI7O0FBRUE7RUFDRSxpQ0FBaUM7QUFDbkM7O0FBRUE7RUFDRSxzQkFBc0I7QUFDeEI7O0FBRUE7RUFDRSxpQ0FBaUM7QUFDbkM7O0FBRUE7RUFDRSxzQkFBc0I7QUFDeEI7O0FBRUE7RUFDRSxpQ0FBaUM7QUFDbkM7O0FBRUE7RUFDRSxzQkFBc0I7QUFDeEI7O0FBRUE7RUFDRSxpQ0FBaUM7QUFDbkM7O0FBRUE7RUFDRSxzQkFBc0I7QUFDeEI7O0FBRUE7RUFDRSxpQ0FBaUM7QUFDbkM7O0FBRUE7RUFDRSxzQkFBc0I7QUFDeEI7O0FBRUE7RUFDRSxpQ0FBaUM7QUFDbkM7O0FBRUE7RUFDRSxzQkFBc0I7QUFDeEI7O0FBRUE7RUFDRSxpQ0FBaUM7QUFDbkM7O0FBRUE7RUFDRSxzQkFBc0I7QUFDeEI7O0FBRUE7RUFDRSxpQ0FBaUM7QUFDbkM7O0FBRUE7RUFDRSxzQkFBc0I7QUFDeEI7O0FBRUE7RUFDRSxpQ0FBaUM7QUFDbkM7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSxrQ0FBa0M7QUFDcEM7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSxrQ0FBa0M7QUFDcEM7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSxrQ0FBa0M7QUFDcEM7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSxrQ0FBa0M7QUFDcEM7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSxrQ0FBa0M7QUFDcEM7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSxrQ0FBa0M7QUFDcEM7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSxrQ0FBa0M7QUFDcEM7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSxrQ0FBa0M7QUFDcEM7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSxrQ0FBa0M7QUFDcEM7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSxrQ0FBa0M7QUFDcEM7O0FBRUE7RUFDRSw0QkFBNEI7QUFDOUI7O0FBRUE7RUFDRSx1Q0FBdUM7QUFDekM7O0FBRUE7RUFDRSxrQ0FBa0M7QUFDcEM7O0FBRUE7RUFDRSw2Q0FBNkM7QUFDL0M7O0FBRUE7RUFDRSxtQ0FBbUM7QUFDckM7O0FBRUE7RUFDRSw4Q0FBOEM7QUFDaEQ7O0FBRUE7RUFDRSw4QkFBOEI7QUFDaEM7O0FBRUE7RUFDRSx5Q0FBeUM7QUFDM0M7O0FBRUE7RUFDRSxvQ0FBb0M7QUFDdEM7O0FBRUE7RUFDRSwrQ0FBK0M7QUFDakQ7O0FBRUE7RUFDRSxxQ0FBcUM7QUFDdkM7O0FBRUE7RUFDRSxnREFBZ0Q7QUFDbEQ7O0FBRUE7RUFDRSw0QkFBNEI7QUFDOUI7O0FBRUE7RUFDRSx1Q0FBdUM7QUFDekM7O0FBRUE7RUFDRSxjQUFjO0FBQ2hCOztBQUVBO0VBQ0UseUJBQXlCO0FBQzNCOztBQUVBO0VBQ0UsY0FBYztBQUNoQjs7QUFFQTtFQUNFLHlCQUF5QjtBQUMzQjs7QUFFQTtFQUNFLGNBQWM7QUFDaEI7O0FBRUE7RUFDRSx5QkFBeUI7QUFDM0I7O0FBRUE7RUFDRSxjQUFjO0FBQ2hCOztBQUVBO0VBQ0UseUJBQXlCO0FBQzNCOztBQUVBO0VBQ0UsY0FBYztBQUNoQjs7QUFFQTtFQUNFLHlCQUF5QjtBQUMzQjs7QUFFQTtFQUNFLGNBQWM7QUFDaEI7O0FBRUE7RUFDRSx5QkFBeUI7QUFDM0I7O0FBRUE7RUFDRSxjQUFjO0FBQ2hCOztBQUVBO0VBQ0UseUJBQXlCO0FBQzNCOztBQUVBO0VBQ0UsY0FBYztBQUNoQjs7QUFFQTtFQUNFLHlCQUF5QjtBQUMzQjs7QUFFQTtFQUNFLGNBQWM7QUFDaEI7O0FBRUE7RUFDRSx5QkFBeUI7QUFDM0I7O0FBRUE7RUFDRSxjQUFjO0FBQ2hCOztBQUVBO0VBQ0UseUJBQXlCO0FBQzNCOztBQUVBO0VBQ0UsY0FBYztBQUNoQjs7QUFFQTtFQUNFLHlCQUF5QjtBQUMzQjs7QUFFQTtFQUNFLGNBQWM7QUFDaEI7O0FBRUE7RUFDRSx5QkFBeUI7QUFDM0I7O0FBRUE7RUFDRSxzSUFBc0k7QUFDeEk7O0FBRUE7RUFDRSwwSUFBMEk7QUFDNUk7O0FBRUE7RUFDRSwySUFBMkk7QUFDN0k7O0FBRUE7RUFDRSx5SUFBeUk7QUFDM0k7O0FBRUE7RUFDRSx3SUFBd0k7QUFDMUk7O0FBRUE7RUFDRSwySUFBMkk7QUFDN0k7O0FBRUE7RUFDRSw2SUFBNkk7QUFDL0k7O0FBRUE7RUFDRSwySUFBMkk7QUFDN0k7O0FBRUE7RUFDRSw2SUFBNkk7QUFDL0k7O0FBRUE7RUFDRSxxQkFBcUI7QUFDdkI7O0FBRUE7RUFDRSxtQkFBbUI7QUFDckI7O0FBRUE7RUFDRSxxQkFBcUI7QUFDdkI7O0FBRUE7RUFDRSx5QkFBeUI7QUFDM0I7O0FBRUE7RUFDRSwwQkFBMEI7QUFDNUI7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSxvQkFBb0I7QUFDdEI7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSxxQkFBcUI7QUFDdkI7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSwyQkFBMkI7QUFDN0I7O0FBRUE7RUFDRSw0QkFBNEI7QUFDOUI7O0FBRUE7RUFDRSx5QkFBeUI7QUFDM0I7O0FBRUE7RUFDRSxzQkFBc0I7QUFDeEI7O0FBRUE7RUFDRSx5QkFBeUI7QUFDM0I7O0FBRUE7RUFDRSx1QkFBdUI7QUFDekI7O0FBRUE7RUFDRSx5QkFBeUI7QUFDM0I7O0FBRUE7RUFDRSw2QkFBNkI7QUFDL0I7O0FBRUE7RUFDRSw4QkFBOEI7QUFDaEM7O0FBRUE7RUFDRSwyQkFBMkI7QUFDN0I7O0FBRUE7RUFDRSx3QkFBd0I7QUFDMUI7O0FBRUE7RUFDRSxzQkFBc0I7QUFDeEI7O0FBRUE7RUFDRSw4QkFBOEI7QUFDaEM7O0FBRUE7RUFDRSxtQkFBbUI7QUFDckI7O0FBRUE7RUFDRSwyQkFBMkI7QUFDN0I7O0FBRUE7RUFDRSxlQUFlO0FBQ2pCOztBQUVBO0VBQ0UsaUJBQWlCO0FBQ25COztBQUVBO0VBQ0UsYUFBYTtBQUNmOztBQUVBO0VBQ0UsU0FBUztFQUNULGVBQWU7QUFDakI7O0FBRUE7RUFDRSxpQkFBaUI7QUFDbkI7QUFDQTtFQUNFLFVBQVU7QUFDWjtBQUNBO0VBQ0UsU0FBUztBQUNYO0FBQ0E7RUFDRTtJQUNFLCtCQUErQjtJQUMvQixnQ0FBZ0M7RUFDbEM7RUFDQTtJQUNFLG9CQUFvQjtJQUNwQixxQkFBcUI7RUFDdkI7RUFDQTtJQUNFLG9CQUFvQjtJQUNwQixxQkFBcUI7RUFDdkI7QUFDRjtBQUNBO0VBQ0U7SUFDRSwrQkFBK0I7SUFDL0IsZ0NBQWdDO0VBQ2xDO0VBQ0E7SUFDRSxxQkFBcUI7SUFDckIsc0JBQXNCO0VBQ3hCO0VBQ0E7SUFDRSxxQkFBcUI7SUFDckIsc0JBQXNCO0VBQ3hCO0FBQ0Y7QUFDQTtFQUNFO0lBQ0UsNkJBQTZCO0lBQzdCLDhCQUE4QjtFQUNoQztFQUNBO0lBQ0Usa0JBQWtCO0lBQ2xCLG1CQUFtQjtFQUNyQjtFQUNBO0lBQ0Usa0JBQWtCO0lBQ2xCLG1CQUFtQjtFQUNyQjtBQUNGOztBQUVBO0VBQ0UsaUJBQWlCO0FBQ25COztBQUVBO0VBQ0UsZ0JBQWdCO0FBQ2xCOztBQUVBO0VBQ0UsZ0JBQWdCO0FBQ2xCOztBQUVBO0VBQ0UsZ0JBQWdCO0FBQ2xCOztBQUVBO0VBQ0UsZ0JBQWdCO0FBQ2xCOztBQUVBO0VBQ0UsZ0JBQWdCO0FBQ2xCOztBQUVBO0VBQ0UsZ0JBQWdCO0FBQ2xCOztBQUVBO0VBQ0UsaUJBQWlCO0FBQ25COztBQUVBO0VBQ0UsaUJBQWlCO0FBQ25COztBQUVBO0VBQ0UsZ0JBQWdCO0FBQ2xCOztBQUVBO0VBQ0Usa0JBQWtCO0FBQ3BCOztBQUVBO0VBQ0Usa0JBQWtCO0FBQ3BCOztBQUVBO0VBQ0Usa0JBQWtCO0FBQ3BCOztBQUVBO0VBQ0Usa0JBQWtCO0FBQ3BCOztBQUVBO0VBQ0UsZ0RBQWdEO0FBQ2xEO0FBQ0E7RUFDRSxrRUFBa0U7QUFDcEU7QUFDQTtFQUNFLGtGQUFrRjtBQUNwRjs7QUFFQTtFQUNFLGdCQUFnQjtBQUNsQjtBQUNBO0VBQ0UsZ0JBQWdCO0FBQ2xCO0FBQ0E7RUFDRSxnQkFBZ0I7QUFDbEI7QUFDQTtFQUNFLGdCQUFnQjtBQUNsQjtBQUNBO0VBQ0UsZ0JBQWdCO0FBQ2xCOztBQUVBO0VBQ0UsZ0JBQWdCO0FBQ2xCO0FBQ0E7RUFDRTtJQUNFLGVBQWU7SUFDZixrQkFBa0I7RUFDcEI7QUFDRjtBQUNBO0VBQ0U7SUFDRSxtQkFBbUI7SUFDbkIsa0JBQWtCO0VBQ3BCO0FBQ0Y7QUFDQTtFQUNFO0lBQ0UsZUFBZTtJQUNmLGtCQUFrQjtFQUNwQjtBQUNGO0FBQ0E7RUFDRTtJQUNFLG1CQUFtQjtJQUNuQixrQkFBa0I7RUFDcEI7QUFDRjs7QUFFQTtFQUNFLGdCQUFnQjtBQUNsQjtBQUNBO0VBQ0U7SUFDRSxtQkFBbUI7SUFDbkIsa0JBQWtCO0VBQ3BCO0FBQ0Y7QUFDQTtFQUNFO0lBQ0UsbUJBQW1CO0lBQ25CLGtCQUFrQjtFQUNwQjtBQUNGO0FBQ0E7RUFDRTtJQUNFLG1CQUFtQjtJQUNuQixrQkFBa0I7RUFDcEI7QUFDRjtBQUNBO0VBQ0U7SUFDRSxrQkFBa0I7SUFDbEIsa0JBQWtCO0VBQ3BCO0FBQ0Y7O0FBRUE7RUFDRSxnQkFBZ0I7QUFDbEI7QUFDQTtFQUNFO0lBQ0UsbUJBQW1CO0lBQ25CLGlCQUFpQjtFQUNuQjtBQUNGO0FBQ0E7RUFDRTtJQUNFLG1CQUFtQjtJQUNuQixnQkFBZ0I7RUFDbEI7QUFDRjtBQUNBO0VBQ0U7SUFDRSxlQUFlO0lBQ2Ysa0JBQWtCO0VBQ3BCO0FBQ0Y7QUFDQTtFQUNFO0lBQ0UsbUJBQW1CO0lBQ25CLGtCQUFrQjtFQUNwQjtBQUNGOztBQUVBO0VBQ0UsZ0JBQWdCO0FBQ2xCO0FBQ0E7RUFDRTtJQUNFLG1CQUFtQjtJQUNuQixrQkFBa0I7RUFDcEI7QUFDRjtBQUNBO0VBQ0U7SUFDRSxtQkFBbUI7SUFDbkIsaUJBQWlCO0VBQ25CO0FBQ0Y7QUFDQTtFQUNFO0lBQ0UsbUJBQW1CO0lBQ25CLHdCQUF3QjtFQUMxQjtBQUNGO0FBQ0E7RUFDRTtJQUNFLGtCQUFrQjtJQUNsQixrQkFBa0I7RUFDcEI7QUFDRjs7QUFFQTtFQUNFLGdCQUFnQjtBQUNsQjtBQUNBO0VBQ0U7SUFDRSxrQkFBa0I7SUFDbEIsZ0JBQWdCO0VBQ2xCO0FBQ0Y7QUFDQTtFQUNFO0lBQ0UsbUJBQW1CO0lBQ25CLGtCQUFrQjtFQUNwQjtBQUNGO0FBQ0E7RUFDRTtJQUNFLG1CQUFtQjtJQUNuQixrQkFBa0I7RUFDcEI7QUFDRjtBQUNBO0VBQ0U7SUFDRSxtQkFBbUI7SUFDbkIsa0JBQWtCO0VBQ3BCO0FBQ0Y7O0FBRUE7RUFDRSxnQkFBZ0I7QUFDbEI7QUFDQTtFQUNFO0lBQ0UsbUJBQW1CO0lBQ25CLGtCQUFrQjtFQUNwQjtBQUNGO0FBQ0E7RUFDRTtJQUNFLG1CQUFtQjtJQUNuQixpQkFBaUI7RUFDbkI7QUFDRjtBQUNBO0VBQ0U7SUFDRSxtQkFBbUI7SUFDbkIsa0JBQWtCO0VBQ3BCO0FBQ0Y7QUFDQTtFQUNFO0lBQ0UsbUJBQW1CO0lBQ25CLGtCQUFrQjtFQUNwQjtBQUNGOztBQUVBO0VBQ0UsZ0JBQWdCO0FBQ2xCO0FBQ0E7RUFDRTtJQUNFLG1CQUFtQjtJQUNuQixrQkFBa0I7RUFDcEI7QUFDRjtBQUNBO0VBQ0U7SUFDRSxtQkFBbUI7SUFDbkIsa0JBQWtCO0VBQ3BCO0FBQ0Y7QUFDQTtFQUNFO0lBQ0UsaUJBQWlCO0lBQ2pCLGNBQWM7RUFDaEI7QUFDRjtBQUNBO0VBQ0U7SUFDRSxtQkFBbUI7SUFDbkIsa0JBQWtCO0VBQ3BCO0FBQ0Y7O0FBRUE7RUFDRSxtQkFBbUI7RUFDbkIsa0JBQWtCO0FBQ3BCO0FBQ0E7RUFDRTtJQUNFLGtCQUFrQjtJQUNsQixnQkFBZ0I7RUFDbEI7QUFDRjs7QUFFQTtFQUNFLG1CQUFtQjtFQUNuQixrQkFBa0I7RUFDbEIsa0ZBQWtGO0FBQ3BGO0FBQ0E7RUFDRTtJQUNFLGtCQUFrQjtJQUNsQixnQkFBZ0I7RUFDbEI7QUFDRjs7QUFFQTtFQUNFO0lBQ0Usa0JBQWtCO0lBQ2xCLGtCQUFrQjtFQUNwQjtBQUNGO0FBQ0E7RUFDRTtJQUNFLG1CQUFtQjtJQUNuQixrQkFBa0I7RUFDcEI7QUFDRjtBQUNBO0VBQ0U7SUFDRSxtQkFBbUI7SUFDbkIsa0JBQWtCO0VBQ3BCO0FBQ0Y7QUFDQTtFQUNFO0lBQ0Usa0JBQWtCO0lBQ2xCLGtCQUFrQjtFQUNwQjtBQUNGOztBQUVBO0VBQ0UsbUJBQW1CO0VBQ25CLGtCQUFrQjtBQUNwQjs7QUFFQTtFQUNFLG1CQUFtQjtFQUNuQixrQkFBa0I7RUFDbEIsZ0JBQWdCO0FBQ2xCOztBQUVBO0VBQ0UsZUFBZTtFQUNmLGdCQUFnQjtBQUNsQjs7QUFFQTtFQUNFLGdCQUFnQjtFQUNoQixrQkFBa0I7QUFDcEI7O0FBRUE7RUFDRSxtQkFBbUI7RUFDbkIsa0JBQWtCO0FBQ3BCOztBQUVBO0VBQ0UsaUJBQWlCO0VBQ2pCLGtCQUFrQjtFQUNsQixnQkFBZ0I7RUFDaEIsbUJBQW1CO0VBQ25CLHlCQUF5QjtBQUMzQjs7QUFFQTs7Ozs7O0VBTUUsZ0JBQWdCO0VBQ2hCLGlCQUFpQjtBQUNuQjs7QUFFQTs7Ozs7O0VBTUUsZ0JBQWdCO0FBQ2xCOztBQUVBO0VBQ0UsY0FBYztBQUNoQjs7QUFFQTs7RUFFRSxjQUFjO0VBQ2QsaUJBQWlCO0FBQ25CO0FBQ0E7RUFDRTs7SUFFRSxnQkFBZ0I7RUFDbEI7QUFDRjtBQUNBO0VBQ0U7O0lBRUUsY0FBYztFQUNoQjtBQUNGOztBQUVBOztFQUVFLGlCQUFpQjtBQUNuQjtBQUNBO0VBQ0U7O0lBRUUsY0FBYztFQUNoQjtBQUNGO0FBQ0E7RUFDRTs7SUFFRSxrQkFBa0I7RUFDcEI7QUFDRjs7QUFFQTs7RUFFRSxpQkFBaUI7QUFDbkI7QUFDQTtFQUNFOztJQUVFLGdCQUFnQjtFQUNsQjtBQUNGO0FBQ0E7RUFDRTs7SUFFRSxrQkFBa0I7RUFDcEI7QUFDRjs7QUFFQTs7RUFFRSxrQkFBa0I7QUFDcEI7O0FBRUE7O0VBRUUsY0FBYztBQUNoQjs7QUFFQTtFQUNFLGlCQUFpQjtFQUNqQixtQkFBbUI7QUFDckI7QUFDQTtFQUNFO0lBQ0UsZ0JBQWdCO0VBQ2xCO0FBQ0Y7QUFDQTtFQUNFO0lBQ0Usa0JBQWtCO0VBQ3BCO0FBQ0Y7O0FBRUE7RUFDRSxvQkFBb0I7QUFDdEI7O0FBRUE7RUFDRSxxQkFBcUI7RUFDckIsZ0JBQWdCO0VBQ2hCLG1CQUFtQjtFQUNuQix5QkFBeUI7QUFDM0I7O0FBRUE7RUFDRSw4QkFBOEI7RUFDOUIsa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQixnSEFBZ0g7RUFDaEgscXFCQUFxcUI7QUFDdnFCO0FBQ0E7RUFDRSw4QkFBOEI7RUFDOUIsa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQixnSEFBZ0g7RUFDaEgscXFCQUFxcUI7QUFDdnFCO0FBQ0E7RUFDRSw4QkFBOEI7RUFDOUIsa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQixnSEFBZ0g7RUFDaEgscXFCQUFxcUI7QUFDdnFCO0FBQ0E7RUFDRSw4QkFBOEI7RUFDOUIsa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQixtSEFBbUg7RUFDbkgsb3JCQUFvckI7QUFDdHJCO0FBQ0E7RUFDRSw4QkFBOEI7RUFDOUIsa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQixnSEFBZ0g7RUFDaEgscXFCQUFxcUI7QUFDdnFCO0FBQ0E7RUFDRSw4QkFBOEI7RUFDOUIsa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQixnSEFBZ0g7RUFDaEgscXFCQUFxcUI7QUFDdnFCO0FBQ0E7RUFDRSw4QkFBOEI7RUFDOUIsa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQixnSEFBZ0g7RUFDaEgscXFCQUFxcUI7QUFDdnFCO0FBQ0E7RUFDRSw4QkFBOEI7RUFDOUIsa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQixnSEFBZ0g7RUFDaEgscXFCQUFxcUI7QUFDdnFCO0FBQ0E7RUFDRSw4QkFBOEI7RUFDOUIsa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQixnSEFBZ0g7RUFDaEgscXFCQUFxcUI7QUFDdnFCO0FBQ0E7RUFDRSw4QkFBOEI7RUFDOUIsa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQixtSEFBbUg7RUFDbkgsb3JCQUFvckI7QUFDdHJCO0FBQ0E7RUFDRSw4QkFBOEI7RUFDOUIsa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQixnSEFBZ0g7RUFDaEgscXFCQUFxcUI7QUFDdnFCO0FBQ0E7RUFDRSw4QkFBOEI7RUFDOUIsa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQixnSEFBZ0g7RUFDaEgscXFCQUFxcUI7QUFDdnFCO0FBQ0E7RUFDRSwyQkFBMkI7RUFDM0Isa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQiw0R0FBNEc7RUFDNUcsOG9CQUE4b0I7QUFDaHBCO0FBQ0E7RUFDRSwyQkFBMkI7RUFDM0Isa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQiw0R0FBNEc7RUFDNUcsOG9CQUE4b0I7QUFDaHBCO0FBQ0E7RUFDRSwyQkFBMkI7RUFDM0Isa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQiw0R0FBNEc7RUFDNUcsOG9CQUE4b0I7QUFDaHBCO0FBQ0E7RUFDRSwyQkFBMkI7RUFDM0Isa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQiw0R0FBNEc7RUFDNUcsOG9CQUE4b0I7QUFDaHBCO0FBQ0E7RUFDRSwyQkFBMkI7RUFDM0Isa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQiw0R0FBNEc7RUFDNUcsOG9CQUE4b0I7QUFDaHBCO0FBQ0E7RUFDRSx3RUFBd0U7RUFDeEUsa0NBQWtDO0VBQ2xDLG1DQUFtQztFQUNuQyxrQkFBa0I7RUFDbEIsUUFBUTtBQUNWO0FBQ0E7O0VBRUUsZ0JBQWdCO0FBQ2xCO0FBQ0E7RUFDRSxpQkFBaUI7RUFDakIsaUJBQWlCO0FBQ25CO0FBQ0E7RUFDRTtJQUNFLGdCQUFnQjtJQUNoQixnQkFBZ0I7RUFDbEI7QUFDRjtBQUNBO0VBQ0UsaUJBQWlCO0VBQ2pCLGdCQUFnQjtBQUNsQjtBQUNBO0VBQ0UsMEJBQTBCO0FBQzVCO0FBQ0E7RUFDRSxnQkFBZ0I7RUFDaEIsZ0JBQWdCO0VBQ2hCLGVBQWU7QUFDakI7QUFDQTtFQUNFLGtCQUFrQjtBQUNwQjtBQUNBO0VBQ0UsaUJBQWlCO0VBQ2pCLGdCQUFnQjtFQUNoQixlQUFlO0FBQ2pCO0FBQ0E7RUFDRSxnQkFBZ0I7RUFDaEIsZUFBZTtBQUNqQjtBQUNBO0VBQ0Usb0JBQW9CO0VBQ3BCLGtCQUFrQjtBQUNwQjtBQUNBOzs7RUFHRSxrRkFBa0Y7RUFDbEYsZ0JBQWdCO0VBQ2hCLGtCQUFrQjtBQUNwQjtBQUNBO0VBQ0UsZ0JBQWdCO0FBQ2xCO0FBQ0E7RUFDRSxnQkFBZ0I7QUFDbEI7QUFDQTtFQUNFLGtDQUFrQztFQUNsQyxxQkFBcUI7RUFDckIsV0FBVztFQUNYLHFCQUFxQjtFQUNyQixjQUFjO0VBQ2QsMkJBQTJCO0VBQzNCLGFBQWE7QUFDZjtBQUNBO0VBQ0UsOEJBQThCO0VBQzlCLGtCQUFrQjtBQUNwQjtBQUNBO0VBQ0UsbUJBQW1CO0VBQ25CLFlBQVk7RUFDWixXQUFXO0VBQ1gsY0FBYztFQUNkLFdBQVc7RUFDWCxrQkFBa0I7RUFDbEIsV0FBVztBQUNiO0FBQ0E7RUFDRTtJQUNFLGdCQUFnQjtFQUNsQjtFQUNBO0lBQ0UsZ0JBQWdCO0VBQ2xCO0FBQ0Y7QUFDQTtFQUNFO0lBQ0UsZ0JBQWdCO0lBQ2hCLGtCQUFrQjtFQUNwQjtFQUNBO0lBQ0UsZ0JBQWdCO0lBQ2hCLGdCQUFnQjtFQUNsQjtFQUNBO0lBQ0Usa0JBQWtCO0VBQ3BCO0FBQ0Y7QUFDQTs7RUFFRSxjQUFjO0FBQ2hCO0FBQ0E7RUFDRSx1QkFBdUI7RUFDdkIsZ0JBQWdCO0FBQ2xCO0FBQ0E7RUFDRSx1QkFBdUI7RUFDdkIsaUJBQWlCO0VBQ2pCLGVBQWU7QUFDakI7O0FBRUE7RUFDRSxlQUFlO0VBQ2Ysa0JBQWtCO0VBQ2xCLFdBQVc7QUFDYjs7QUFFQTtFQUNFLGVBQWU7RUFDZixrQkFBa0I7RUFDbEIsV0FBVztBQUNiOztBQUVBO0VBQ0UsZUFBZTtFQUNmLGtCQUFrQjtFQUNsQixXQUFXO0FBQ2I7O0FBRUE7RUFDRSxZQUFZO0VBQ1osZ0JBQWdCO0VBQ2hCLGtCQUFrQjtBQUNwQjs7QUFFQTtFQUNFLFlBQVk7RUFDWixnQkFBZ0I7RUFDaEIsa0JBQWtCO0FBQ3BCOztBQUVBO0VBQ0UsWUFBWTtFQUNaLGdCQUFnQjtFQUNoQixrQkFBa0I7QUFDcEI7O0FBRUE7RUFDRSwyQkFBMkI7RUFDM0IsNEJBQTRCO0VBQzVCLHNCQUFzQjtBQUN4QjtBQUNBOzs7RUFHRSxZQUFZO0VBQ1osa0JBQWtCO0VBQ2xCLFdBQVc7QUFDYjtBQUNBOzs7RUFHRSxZQUFZO0VBQ1osT0FBTztFQUNQLG9CQUFpQjtLQUFqQixpQkFBaUI7RUFDakIsa0JBQWtCO0VBQ2xCLFdBQVc7QUFDYjs7QUFFQTtFQUNFLFlBQVk7RUFDWixXQUFXO0FBQ2I7QUFDQTs7RUFFRSxtQkFBbUI7RUFDbkIsYUFBYTtFQUNiLFlBQVk7RUFDWixrQkFBa0I7RUFDbEIsV0FBVztFQUNYLHFCQUFxQjtBQUN2QjtBQUNBOztFQUVFLFlBQVk7RUFDWixXQUFXO0FBQ2I7QUFDQTtFQUNFLHlCQUF5QjtFQUN6QixhQUFhO0VBQ2IsWUFBWTtFQUNaLHVCQUF1QjtFQUN2QixrQkFBa0I7RUFDbEIsV0FBVztBQUNiO0FBQ0E7RUFDRSxrQkFBa0I7RUFDbEIsUUFBUTtFQUNSLDJCQUEyQjtBQUM3Qjs7QUFFQTtFQUNFO0lBQ0Usd0JBQXdCO0VBQzFCO0FBQ0Y7O0FBRUE7RUFDRTtJQUNFLHdCQUF3QjtFQUMxQjtBQUNGOztBQUVBO0VBQ0U7SUFDRSx3QkFBd0I7RUFDMUI7QUFDRjs7QUFFQTtFQUNFO0lBQ0Usd0JBQXdCO0VBQzFCO0FBQ0Y7O0FBRUE7RUFDRTtJQUNFLHdCQUF3QjtFQUMxQjtBQUNGOztBQUVBO0VBQ0UscUJBQXFCO0FBQ3ZCOztBQUVBO0VBQ0UsbUJBQW1CO0FBQ3JCO0FBQ0E7RUFDRSx1QkFBdUI7QUFDekI7QUFDQTtFQUNFLHFCQUFxQjtBQUN2QjtBQUNBO0VBQ0Usc0JBQXNCO0VBQ3RCLGFBQWE7RUFDYixlQUFlO0VBQ2YsWUFBWTtBQUNkO0FBQ0E7RUFDRSxzQkFBc0I7QUFDeEI7QUFDQTtFQUNFLGNBQWM7RUFDZCxVQUFVO0FBQ1o7QUFDQTtFQUNFLGlCQUFpQjtFQUNqQixrQkFBa0I7RUFDbEIsY0FBYztFQUNkLHFCQUFxQjtBQUN2QjtBQUNBO0VBQ0U7SUFDRSxjQUFjO0VBQ2hCO0FBQ0Y7QUFDQTtFQUNFLGlCQUFpQjtBQUNuQjtBQUNBO0VBQ0U7SUFDRSxzQkFBc0I7RUFDeEI7QUFDRjtBQUNBO0VBQ0UsMEJBQTBCO0VBQzFCLHdCQUF3QjtBQUMxQjtBQUNBO0VBQ0Usd0JBQXdCO0VBQ3hCLHNCQUFzQjtBQUN4QjtBQUNBO0VBQ0UseUJBQXlCO0VBQ3pCLHVCQUF1QjtBQUN6QjtBQUNBO0VBQ0UsdUJBQXVCO0VBQ3ZCLHFCQUFxQjtBQUN2QjtBQUNBO0VBQ0UsYUFBYTtBQUNmO0FBQ0E7RUFDRSxzQkFBc0I7QUFDeEI7QUFDQTtFQUNFLDhCQUE4QjtBQUNoQztBQUNBO0VBQ0UsbUJBQW1CO0FBQ3JCO0FBQ0E7RUFDRSwyQkFBMkI7QUFDN0I7QUFDQTtFQUNFLGdCQUFnQjtBQUNsQjtBQUNBO0VBQ0UsZ0JBQWdCO0FBQ2xCO0FBQ0E7RUFDRSwwQkFBMEI7QUFDNUI7QUFDQTtFQUNFLGVBQWU7QUFDakI7QUFDQTtFQUNFLHVCQUF1QjtBQUN6QjtBQUNBO0VBQ0UseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSw2QkFBNkI7QUFDL0I7QUFDQTtFQUNFLDhCQUE4QjtBQUNoQztBQUNBO0VBQ0UsMkJBQTJCO0FBQzdCO0FBQ0E7Ozs7RUFJRSxzQkFBc0I7RUFDdEIsY0FBYztFQUNkLGNBQWM7QUFDaEI7QUFDQTtFQUNFLGlCQUFpQjtBQUNuQjtBQUNBO0VBQ0UsZ0JBQWdCO0FBQ2xCO0FBQ0E7RUFDRSxnQkFBZ0I7QUFDbEI7QUFDQTtFQUNFLGdCQUFnQjtBQUNsQjtBQUNBO0VBQ0UsVUFBVTtBQUNaO0FBQ0E7RUFDRSwwQkFBMEI7RUFDMUIsMkJBQTJCO0FBQzdCO0FBQ0E7RUFDRSw0QkFBNEI7RUFDNUIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSxjQUFjO0FBQ2hCO0FBQ0E7RUFDRSxtQkFBbUI7RUFDbkIsb0JBQW9CO0FBQ3RCO0FBQ0E7RUFDRSxxQkFBcUI7RUFDckIsa0JBQWtCO0FBQ3BCO0FBQ0E7RUFDRSxZQUFZO0FBQ2Q7QUFDQTtFQUNFLGlCQUFpQjtFQUNqQixrQkFBa0I7QUFDcEI7QUFDQTtFQUNFLG1CQUFtQjtFQUNuQixnQkFBZ0I7QUFDbEI7O0FBRUE7O0VBRUUsNEZBQTRGO0FBQzlGO0FBQ0E7Ozs7RUFJRSw2QkFBNkI7QUFDL0I7O0FBRUE7RUFDRSxtQkFBbUI7QUFDckI7O0FBRUE7RUFDRSxtQkFBbUI7QUFDckI7O0FBRUE7RUFDRSx3RUFBd0U7QUFDMUU7QUFDQTs7O0VBR0UsaUNBQWlDO0FBQ25DO0FBQ0E7RUFDRTtJQUNFLGtCQUFrQjtFQUNwQjtBQUNGOztBQUVBO0VBQ0UsZUFBZTtFQUNmLGdCQUFnQjtFQUNoQixxQkFBcUI7QUFDdkI7O0FBRUE7O0VBRUUsZUFBZTtFQUNmLHFCQUFxQjtBQUN2Qjs7QUFFQTtFQUNFLGtGQUFrRjtBQUNwRjs7QUFFQTtFQUNFLCtEQUErRDtBQUNqRTs7QUFFQTtFQUNFLDREQUE0RDtBQUM5RDs7QUFFQTtFQUNFLGlFQUFpRTtBQUNuRTs7QUFFQTtFQUNFLGdCQUFnQjtBQUNsQjs7QUFFQTtFQUNFLGtCQUFrQjtFQUNsQixjQUFjO0VBQ2QsYUFBYTtBQUNmOztBQUVBO0VBQ0UsYUFBYTtFQUNiLFlBQVk7QUFDZDs7QUFFQTtFQUNFLFlBQVk7QUFDZDs7QUFFQTtFQUNFLDRCQUE0QjtFQUM1QixlQUFlO0FBQ2pCO0FBQ0E7RUFDRSw0QkFBNEI7QUFDOUI7QUFDQTtFQUNFLGtDQUFrQztBQUNwQztBQUNBO0VBQ0Usa0NBQWtDO0FBQ3BDO0FBQ0E7RUFDRSxtQ0FBbUM7QUFDckM7QUFDQTtFQUNFLDRCQUE0QjtBQUM5QjtBQUNBO0VBQ0UsdUJBQXVCO0VBQ3ZCLGVBQWU7RUFDZiwwQkFBMEI7QUFDNUI7QUFDQTtFQUNFLHVCQUF1QjtBQUN6QjtBQUNBO0VBQ0UsdUJBQXVCO0FBQ3pCO0FBQ0E7RUFDRSx1QkFBdUI7QUFDekI7QUFDQTtFQUNFLHVCQUF1QjtBQUN6QjtBQUNBO0VBQ0UsdUJBQXVCO0FBQ3pCO0FBQ0E7RUFDRSw4QkFBOEI7QUFDaEM7QUFDQTtFQUNFLDhCQUE4QjtBQUNoQztBQUNBO0VBQ0UsOEJBQThCO0FBQ2hDO0FBQ0E7RUFDRSw4QkFBOEI7QUFDaEM7QUFDQTtFQUNFLDhCQUE4QjtBQUNoQztBQUNBO0VBQ0UsOEJBQThCO0FBQ2hDO0FBQ0E7RUFDRSwwQkFBMEI7QUFDNUI7QUFDQTtFQUNFLHFCQUFxQjtBQUN2QjtBQUNBO0VBQ0UsbUJBQW1CO0VBQ25CLDZCQUE2QjtFQUM3QixlQUFlO0VBQ2YsdUJBQXVCO0VBQ3ZCLG9CQUFvQjtFQUNwQixpQkFBaUI7RUFDakIsaUJBQWlCO0VBQ2pCLGVBQWU7RUFDZixVQUFVO0VBQ1YscUJBQXFCO0VBQ3JCLHFCQUFxQjtBQUN2QjtBQUNBO0VBQ0UsdUJBQXVCO0FBQ3pCO0FBQ0E7RUFDRSx1QkFBdUI7RUFDdkIscUJBQXFCO0FBQ3ZCO0FBQ0E7RUFDRSx1QkFBdUI7QUFDekI7QUFDQTtFQUNFLG1CQUFtQjtBQUNyQjtBQUNBO0VBQ0UsNkJBQTZCO0VBQzdCLHVCQUF1QjtBQUN6QjtBQUNBO0VBQ0UsZUFBZTtBQUNqQjtBQUNBO0VBQ0UsY0FBYztFQUNkLFlBQVk7QUFDZDs7QUFFQTtFQUNFLG1CQUFtQjtFQUNuQiw2QkFBNkI7RUFDN0IsZUFBZTtFQUNmLDRCQUE0QjtFQUM1QixvQkFBb0I7RUFDcEIsbUJBQW1CO0VBQ25CLGdCQUFnQjtFQUNoQixpQkFBaUI7RUFDakIsZUFBZTtFQUNmLHFCQUFxQjtFQUNyQixxQkFBcUI7QUFDdkI7QUFDQTtFQUNFLDRCQUE0QjtBQUM5QjtBQUNBO0VBQ0Usa0NBQWtDO0VBQ2xDLHFCQUFxQjtBQUN2QjtBQUNBO0VBQ0Usa0NBQWtDO0FBQ3BDO0FBQ0E7RUFDRSxtQ0FBbUM7QUFDckM7QUFDQTtFQUNFLDZCQUE2QjtFQUM3Qiw0QkFBNEI7QUFDOUI7QUFDQTtFQUNFLGVBQWU7QUFDakI7QUFDQTtFQUNFLGNBQWM7RUFDZCxlQUFlO0FBQ2pCO0FBQ0E7RUFDRSxpQkFBaUI7RUFDakIsWUFBWTtBQUNkOztBQUVBO0VBQ0UsK0JBQStCO0FBQ2pDO0FBQ0E7RUFDRSw4QkFBOEI7QUFDaEM7QUFDQTtFQUNFLCtCQUErQjtBQUNqQzs7QUFFQTtFQUNFLGlCQUFpQjtFQUNqQixpQkFBaUI7QUFDbkI7QUFDQTtFQUNFLGlCQUFpQjtFQUNqQixhQUFhO0FBQ2Y7O0FBRUE7O0VBRUUsbUJBQW1CO0FBQ3JCO0FBQ0E7O0VBRUUsbUJBQW1CO0FBQ3JCO0FBQ0E7O0VBRUUsbUJBQW1CO0FBQ3JCO0FBQ0E7OztFQUdFLG1CQUFtQjtBQUNyQjtBQUNBOzs7RUFHRSxtQkFBbUI7QUFDckI7QUFDQTs7O0VBR0UsbUJBQW1CO0FBQ3JCO0FBQ0E7RUFDRSw2QkFBNkI7RUFDN0IseUJBQXlCO0VBQ3pCLG1CQUFtQjtFQUNuQixpQkFBaUI7RUFDakIsa0JBQWtCO0VBQ2xCLDBJQUEwSTtFQUMxSSxtQkFBbUI7RUFDbkIsZUFBZTtFQUNmLHFCQUFxQjtFQUNyQixjQUFjO0VBQ2QsZ0JBQWdCO0VBQ2hCLGNBQWM7RUFDZCx3QkFBd0I7RUFDeEIsZUFBZTtFQUNmLHlCQUF5QjtFQUN6QixrQkFBa0I7RUFDbEIsbUJBQW1CO0VBQ25CLHNCQUFzQjtFQUN0QixrQkFBa0I7RUFDbEIsZ0NBQWdDO0VBQ2hDLHlCQUFpQjtLQUFqQixzQkFBaUI7TUFBakIscUJBQWlCO1VBQWpCLGlCQUFpQjtFQUNqQixzQkFBc0I7RUFDdEIscUJBQXFCO0VBQ3JCLFVBQVU7QUFDWjtBQUNBO0VBQ0UsbUJBQW1CO0FBQ3JCO0FBQ0E7RUFDRSwySUFBMkk7RUFDM0ksbUJBQW1CO0VBQ25CLHFCQUFxQjtFQUNyQixzQ0FBc0M7RUFDdEMsb0JBQW9CO0FBQ3RCO0FBQ0E7RUFDRSxnQ0FBZ0M7RUFDaEMsbUJBQW1CO0VBQ25CLFVBQVU7RUFDVixzQ0FBc0M7RUFDdEMsb0JBQW9CO0FBQ3RCO0FBQ0E7RUFDRSw2Q0FBNkM7RUFDN0MsbUJBQW1CO0VBQ25CLHdCQUF3QjtFQUN4QixvQkFBb0I7QUFDdEI7QUFDQTtFQUNFLDZCQUE2QjtFQUM3Qix5QkFBeUI7RUFDekIsMElBQTBJO0VBQzFJLG1CQUFtQjtFQUNuQixtQkFBbUI7RUFDbkIsWUFBWTtFQUNaLGVBQWU7QUFDakI7QUFDQTtFQUNFLG9CQUFvQjtBQUN0Qjs7QUFFQTtFQUNFLG9CQUFvQjtFQUNwQixrQkFBa0I7QUFDcEI7QUFDQTtFQUNFLGFBQWE7RUFDYixlQUFlO0VBQ2Ysa0JBQWtCO0VBQ2xCLFFBQVE7RUFDUiwyQkFBMkI7RUFDM0IsWUFBWTtBQUNkOztBQUVBO0VBQ0UscUJBQXFCO0VBQ3JCLGtCQUFrQjtBQUNwQjtBQUNBO0VBQ0UsYUFBYTtFQUNiLGtCQUFrQjtFQUNsQixnQkFBZ0I7RUFDaEIsUUFBUTtFQUNSLDJCQUEyQjtFQUMzQixZQUFZO0FBQ2Q7O0FBRUE7RUFDRSxrQkFBa0I7RUFDbEIsd0JBQXdCO0VBQ3hCLHVCQUF1QjtFQUN2Qix3QkFBd0I7RUFDeEIscUJBQXFCO0FBQ3ZCO0FBQ0E7RUFDRSxxQkFBcUI7QUFDdkI7QUFDQTtFQUNFLGFBQWE7QUFDZjtBQUNBO0VBQ0Usc0JBQXNCO0FBQ3hCO0FBQ0E7RUFDRSxjQUFjO0FBQ2hCOztBQUVBO0VBQ0Usa0JBQWtCO0VBQ2xCLG1CQUFtQjtFQUNuQixzQkFBc0I7RUFDdEIsb0JBQW9CO0VBQ3BCLHFCQUFxQjtFQUNyQixtQkFBbUI7QUFDckI7QUFDQTtFQUNFO0lBQ0UsU0FBUztFQUNYO0FBQ0Y7QUFDQTtFQUNFLHFCQUFxQjtBQUN2QjtBQUNBO0VBQ0UsYUFBYTtBQUNmO0FBQ0E7RUFDRSxzQkFBc0I7QUFDeEI7QUFDQTtFQUNFLGNBQWM7QUFDaEI7O0FBRUE7RUFDRSxjQUFjO0VBQ2QsV0FBVztBQUNiOztBQUVBO0VBQ0UsbUJBQW1CO0VBQ25CLGdCQUFnQjtFQUNoQixvQkFBb0I7RUFDcEIsY0FBYztFQUNkLHVCQUF1QjtFQUN2QixjQUFjO0VBQ2QsVUFBVTtFQUNWLGVBQWU7RUFDZixhQUFhO0FBQ2Y7QUFDQTtFQUNFLGdCQUFnQjtFQUNoQixlQUFlO0FBQ2pCO0FBQ0E7RUFDRSxnQkFBZ0I7RUFDaEIsZUFBZTtBQUNqQjtBQUNBO0VBQ0UsZ0JBQWdCO0FBQ2xCO0FBQ0E7RUFDRSxZQUFZO0VBQ1osV0FBVztBQUNiO0FBQ0E7RUFDRSxZQUFZO0VBQ1osV0FBVztBQUNiO0FBQ0E7RUFDRSxnQkFBZ0I7RUFDaEIsYUFBYTtFQUNiLGdCQUFnQjtBQUNsQjtBQUNBO0VBQ0UsZUFBZTtBQUNqQjtBQUNBO0VBQ0UsZUFBZTtBQUNqQjtBQUNBO0VBQ0UsZUFBZTtFQUNmLGdCQUFnQjtBQUNsQjtBQUNBO0VBQ0UsdUNBQXVDO0VBQ3ZDLG1DQUFtQztFQUNuQyxtQkFBbUI7QUFDckI7QUFDQTtFQUNFLG1CQUFtQjtBQUNyQjtBQUNBO0VBQ0UsNkNBQTZDO0VBQzdDLHlDQUF5QztFQUN6QyxtQkFBbUI7QUFDckI7QUFDQTtFQUNFLDZDQUE2QztFQUM3Qyx5Q0FBeUM7RUFDekMsbUJBQW1CO0FBQ3JCO0FBQ0E7RUFDRSw4Q0FBOEM7RUFDOUMsMENBQTBDO0VBQzFDLG1CQUFtQjtBQUNyQjtBQUNBO0VBQ0UsdUNBQXVDO0VBQ3ZDLG1DQUFtQztFQUNuQyxtQkFBbUI7QUFDckI7QUFDQTtFQUNFLDhCQUE4QjtFQUM5QiwwQkFBMEI7RUFDMUIsNEJBQTRCO0FBQzlCO0FBQ0E7RUFDRSw0QkFBNEI7QUFDOUI7QUFDQTtFQUNFLGtDQUFrQztBQUNwQztBQUNBO0VBQ0Usa0NBQWtDO0FBQ3BDO0FBQ0E7RUFDRSxtQ0FBbUM7QUFDckM7QUFDQTtFQUNFLDhCQUE4QjtFQUM5QiwwQkFBMEI7RUFDMUIsNEJBQTRCO0FBQzlCO0FBQ0E7RUFDRSxpQ0FBaUM7RUFDakMsNkJBQTZCO0VBQzdCLG1CQUFtQjtBQUNyQjtBQUNBO0VBQ0UsbUJBQW1CO0FBQ3JCO0FBQ0E7RUFDRSx5QkFBeUI7RUFDekIscUJBQXFCO0VBQ3JCLG1CQUFtQjtBQUNyQjtBQUNBO0VBQ0UseUJBQXlCO0VBQ3pCLHFCQUFxQjtFQUNyQixtQkFBbUI7QUFDckI7QUFDQTtFQUNFLHlCQUF5QjtFQUN6QixxQkFBcUI7RUFDckIsbUJBQW1CO0FBQ3JCO0FBQ0E7RUFDRSxpQ0FBaUM7RUFDakMsNkJBQTZCO0VBQzdCLG1CQUFtQjtBQUNyQjtBQUNBO0VBQ0UsNkJBQTZCO0VBQzdCLGdCQUFnQjtFQUNoQiw0QkFBNEI7RUFDNUIsZUFBZTtFQUNmLHFCQUFxQjtFQUNyQixtQkFBbUI7RUFDbkIsZ0JBQWdCO0VBQ2hCLGVBQWU7RUFDZix3QkFBd0I7RUFDeEIscUJBQXFCO0FBQ3ZCO0FBQ0E7RUFDRSw0QkFBNEI7QUFDOUI7QUFDQTtFQUNFLGdCQUFnQjtFQUNoQiw0QkFBNEI7QUFDOUI7QUFDQTtFQUNFLGdCQUFnQjtFQUNoQiw0QkFBNEI7QUFDOUI7QUFDQTtFQUNFLDRCQUE0QjtBQUM5QjtBQUNBO0VBQ0UsNkJBQTZCO0VBQzdCLGdCQUFnQjtFQUNoQiw0QkFBNEI7QUFDOUI7QUFDQTtFQUNFLGtCQUFrQjtBQUNwQjtBQUNBO0VBQ0UsU0FBUztFQUNULGFBQWE7QUFDZjtBQUNBO0VBQ0UsbUJBQW1CO0FBQ3JCO0FBQ0E7RUFDRSxhQUFhO0VBQ2IsVUFBVTtBQUNaO0FBQ0E7RUFDRSx3QkFBd0I7RUFDeEIscUJBQXFCO0FBQ3ZCO0FBQ0E7RUFDRSxpQkFBaUI7RUFDakIsaUJBQWlCO0VBQ2pCLDBCQUEwQjtFQUMxQix1QkFBdUI7QUFDekI7QUFDQTtFQUNFLG9CQUFvQjtBQUN0QjtBQUNBO0VBQ0UsU0FBUztBQUNYO0FBQ0E7RUFDRSxxQkFBcUI7QUFDdkI7QUFDQTtFQUNFLFVBQVU7QUFDWjs7QUFFQTtFQUNFLDBJQUEwSTtFQUMxSSxlQUFlO0VBQ2YsbUJBQW1CO0VBQ25CLGdCQUFnQjtFQUNoQixxQkFBcUI7RUFDckIsZ0NBQWdDO0FBQ2xDO0FBQ0E7RUFDRSw4QkFBOEI7RUFDOUIsMklBQTJJO0VBQzNJLGtDQUFrQztFQUNsQyxxQkFBcUI7RUFDckIsc0NBQXNDO0VBQ3RDLG9CQUFvQjtBQUN0Qjs7QUFFQTtFQUNFLGdCQUFnQjtBQUNsQjs7QUFFQTtFQUNFO0lBQ0UsZ0JBQWdCO0VBQ2xCO0VBQ0E7SUFDRSxtQkFBbUI7RUFDckI7RUFDQTtJQUNFLG1CQUFtQjtFQUNyQjtBQUNGO0FBQ0E7RUFDRSxlQUFlO0FBQ2pCO0FBQ0E7RUFDRSxrQkFBa0I7RUFDbEIsU0FBUztBQUNYOztBQUVBO0VBQ0UsNklBQTZJO0VBQzdJLE1BQU07QUFDUjs7QUFFQTtFQUNFLFNBQVM7QUFDWDtBQUNBO0VBQ0U7SUFDRSxTQUFTO0VBQ1g7QUFDRjtBQUNBO0VBQ0UsU0FBUztBQUNYO0FBQ0E7RUFDRSxTQUFTO0FBQ1g7QUFDQTs7O0VBR0UsZUFBZTtFQUNmLHNCQUFzQjtBQUN4QjtBQUNBO0VBQ0Usc0JBQXNCO0FBQ3hCOztBQUVBO0VBQ0UsV0FBVztBQUNiOztBQUVBO0VBQ0UsaUJBQWlCO0FBQ25CO0FBQ0E7RUFDRSxrQkFBa0I7QUFDcEI7QUFDQTtFQUNFO0lBQ0UsaUJBQWlCO0VBQ25CO0FBQ0Y7O0FBRUE7RUFDRTtJQUNFLHFDQUFxQztFQUN2QztFQUNBOztJQUVFLDZCQUE2QjtFQUMvQjtFQUNBO0lBQ0Usd0JBQXdCO0VBQzFCO0VBQ0E7SUFDRSw2QkFBNkI7SUFDN0IsWUFBWTtFQUNkO0VBQ0E7SUFDRSw4QkFBOEI7RUFDaEM7QUFDRjtBQUNBO0VBQ0U7SUFDRSwwQkFBMEI7SUFDMUIsbUJBQW1CO0VBQ3JCO0VBQ0E7SUFDRSxxQ0FBcUM7RUFDdkM7RUFDQTtJQUNFLGFBQWE7RUFDZjtBQUNGO0FBQ0E7RUFDRTtJQUNFLHFDQUFxQztJQUNyQyxnQ0FBZ0M7RUFDbEM7RUFDQTtJQUNFLGFBQWE7RUFDZjtFQUNBO0lBQ0UsbUJBQW1CO0lBQ25CLFVBQVU7RUFDWjtFQUNBO0lBQ0Usa0JBQWtCO0VBQ3BCO0FBQ0Y7O0FBRUE7RUFDRSxZQUFZO0VBQ1osT0FBTztFQUNQLGVBQWU7RUFDZixRQUFRO0VBQ1IsTUFBTTtFQUNOLGdDQUFnQztFQUNoQyx1QkFBdUI7RUFDdkIsWUFBWTtBQUNkO0FBQ0E7RUFDRSxZQUFZO0FBQ2Q7QUFDQTtFQUNFLDhCQUE4QjtBQUNoQztBQUNBO0VBQ0Usc0JBQXNCO0FBQ3hCO0FBQ0E7RUFDRSxhQUFhO0FBQ2Y7QUFDQTtFQUNFLGFBQWE7RUFDYixrQkFBa0I7RUFDbEIsZ0JBQWdCO0VBQ2hCLGdCQUFnQjtFQUNoQixlQUFlO0FBQ2pCO0FBQ0E7RUFDRSw4QkFBOEI7QUFDaEM7QUFDQTtFQUNFLHlCQUF5QjtFQUN6QixrQ0FBa0M7QUFDcEM7QUFDQTtFQUNFLGFBQWE7QUFDZjtBQUNBO0VBQ0UsbUhBQW1IO0FBQ3JIO0FBQ0E7RUFDRSx5QkFBeUI7RUFDekIsa0JBQWtCO0FBQ3BCO0FBQ0E7RUFDRSxtQ0FBbUM7QUFDckM7QUFDQTtFQUNFLFNBQVM7RUFDVCxVQUFVO0VBQ1Ysd0JBQXdCO0VBQ3hCLG1CQUFtQjtBQUNyQjtBQUNBO0VBQ0UsNEJBQTRCO0VBQzVCLHNCQUFzQjtFQUN0QixxQkFBcUI7RUFDckIsbUJBQW1CO0VBQ25CLGVBQWU7RUFDZixjQUFjO0VBQ2QsV0FBVztFQUNYLE9BQU87RUFDUCxnQkFBZ0I7RUFDaEIscUJBQXFCO0VBQ3JCLGdCQUFnQjtFQUNoQixlQUFlO0VBQ2YsZ0JBQWdCO0VBQ2hCLFVBQVU7RUFDVixjQUFjO0VBQ2QsOEJBQThCO0VBQzlCLGtCQUFrQjtFQUNsQixRQUFRO0VBQ1IsNkJBQTZCO0VBQzdCLHNHQUFzRztFQUN0RyxrQkFBa0I7RUFDbEIsV0FBVztBQUNiO0FBQ0E7RUFDRSxXQUFXO0FBQ2I7QUFDQTtFQUNFLGlCQUFhO0VBQWIsYUFBYTtFQUNiLHFCQUFxQjtFQUNyQixvQkFBb0I7RUFDcEIsd0hBQXNDO0VBQXRDLHNDQUFzQztFQUN0QyxjQUFjO0VBQ2QsaUJBQWlCO0VBQ2pCLFdBQVc7QUFDYjtBQUNBO0VBQ0UseUNBQXlDO0VBQ3pDLG9CQUFvQjtFQUNwQixvQkFBb0I7RUFDcEIsb0JBQW9CO0VBQ3BCLHNCQUFzQjtFQUN0QixnQkFBZ0I7RUFDaEIsb0JBQW9CO0VBQ3BCLHNCQUFzQjtBQUN4QjtBQUNBO0VBQ0UsYUFBYTtFQUNiLGdCQUFnQjtFQUNoQixnQkFBZ0I7QUFDbEI7QUFDQTtFQUNFLGVBQWU7QUFDakI7QUFDQTtFQUNFLGFBQWE7RUFDYixnRUFBZ0U7RUFDaEUseUJBQWlCO0tBQWpCLHNCQUFpQjtNQUFqQixxQkFBaUI7VUFBakIsaUJBQWlCO0FBQ25CO0FBQ0E7RUFDRSx5QkFBeUI7RUFDekIsb0JBQW9CO0VBQ3BCLDZCQUE2QjtFQUM3QixhQUFhO0VBQ2IscUJBQXFCO0FBQ3ZCO0FBQ0E7RUFDRSxrQ0FBa0M7QUFDcEM7QUFDQTtFQUNFLHNCQUFzQjtBQUN4QjtBQUNBO0VBQ0Usa0JBQWtCO0VBQ2xCLFlBQVk7RUFDWixrQkFBa0I7RUFDbEIsb0JBQWlCO0tBQWpCLGlCQUFpQjtFQUNqQixXQUFXO0FBQ2I7QUFDQTtFQUNFLGlCQUFpQjtFQUNqQixxQkFBcUI7RUFDckIsb0JBQW9CO0VBQ3BCLHNCQUFzQjtFQUN0Qix5QkFBeUI7QUFDM0I7QUFDQTtFQUVFLGtCQUFrQjtFQUNsQix3QkFBd0I7RUFDeEIsaUJBQWlCO0VBQ2pCLGFBQWE7RUFDYixxQkFBcUI7RUFDckIsc0JBQXNCO0VBQ3RCLG1DQUEyQjtFQUEzQiwyQkFBMkI7RUFDM0IscUJBQXFCO0VBQ3JCLG9CQUFvQjtFQUNwQixnQkFBZ0I7RUFDaEIsZUFBZTtFQUNmLFdBQVc7QUFDYjtBQUNBO0VBQ0Usa0NBQWtDO0VBQ2xDLGtCQUFrQjtFQUNsQixhQUFhO0FBQ2Y7QUFDQTtFQUNFLHVCQUF1QjtFQUN2Qix1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx1QkFBdUI7RUFDdkIsdUJBQXlCO01BQXpCLHlCQUF5QjtBQUMzQjtBQUNBO0VBQ0UsdUJBQXVCO0VBQ3ZCLHVCQUF5QjtNQUF6Qix5QkFBeUI7QUFDM0I7QUFDQTtFQUNFLHVCQUF1QjtFQUN2Qix1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx1QkFBdUI7RUFDdkIsdUJBQXlCO01BQXpCLHlCQUF5QjtBQUMzQjtBQUNBO0VBQ0UseUJBQXlCO0VBQ3pCLHVCQUF1QjtFQUN2Qix1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx1QkFBdUI7RUFDdkIsdUJBQXlCO01BQXpCLHlCQUF5QjtBQUMzQjtBQUNBO0VBQ0UseUJBQXlCO0VBQ3pCLHVCQUF1QjtFQUN2Qix1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx1QkFBdUI7RUFDdkIsdUJBQXlCO01BQXpCLHlCQUF5QjtBQUMzQjtBQUNBO0VBQ0UseUJBQXlCO0VBQ3pCLHVCQUF1QjtFQUN2Qix1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx1QkFBdUI7RUFDdkIsdUJBQXlCO01BQXpCLHlCQUF5QjtBQUMzQjtBQUNBO0VBQ0UseUJBQXlCO0VBQ3pCLHVCQUF1QjtFQUN2Qix1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx1QkFBdUI7RUFDdkIsdUJBQXlCO01BQXpCLHlCQUF5QjtBQUMzQjtBQUNBO0VBQ0UseUJBQXlCO0VBQ3pCLHVCQUF1QjtFQUN2Qix1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx3QkFBd0I7RUFDeEIsd0JBQTBCO01BQTFCLDBCQUEwQjtBQUM1QjtBQUNBO0VBQ0UsMEJBQTBCO0VBQzFCLHdCQUF3QjtFQUN4Qix3QkFBMEI7TUFBMUIsMEJBQTBCO0FBQzVCO0FBQ0E7RUFDRSx3QkFBd0I7RUFDeEIsd0JBQTBCO01BQTFCLDBCQUEwQjtBQUM1QjtBQUNBO0VBQ0UsMEJBQTBCO0VBQzFCLHdCQUF3QjtFQUN4Qix3QkFBMEI7TUFBMUIsMEJBQTBCO0FBQzVCO0FBQ0E7RUFDRSx3QkFBd0I7RUFDeEIsd0JBQTBCO01BQTFCLDBCQUEwQjtBQUM1QjtBQUNBO0VBQ0UsMEJBQTBCO0VBQzFCLHdCQUF3QjtFQUN4Qix3QkFBMEI7TUFBMUIsMEJBQTBCO0FBQzVCO0FBQ0E7RUFDRSx1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx1QkFBeUI7TUFBekIseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx3QkFBMEI7TUFBMUIsMEJBQTBCO0FBQzVCO0FBQ0E7RUFDRSx3QkFBMEI7TUFBMUIsMEJBQTBCO0FBQzVCO0FBQ0E7RUFDRSx3QkFBMEI7TUFBMUIsMEJBQTBCO0FBQzVCO0FBQ0E7RUFDRSw4QkFBOEI7RUFDOUIsdUJBQXVCO0VBQ3ZCLGdCQUFnQjtFQUNoQixrQkFBa0I7RUFDbEIscUJBQXFCO0VBQ3JCLCtCQUErQjtFQUMvQiw0Q0FBNEM7RUFDNUMsc0NBQXNDO0FBQ3hDO0FBQ0E7RUFDRSx5QkFBeUI7RUFDekIsa0NBQWtDO0FBQ3BDO0FBQ0E7O0VBRUUsZ0JBQWdCO0FBQ2xCO0FBQ0E7RUFDRSxnQkFBZ0I7RUFDaEIsVUFBVTtFQUNWLHFDQUFxQztFQUNyQyxVQUFVO0FBQ1o7QUFDQTtFQUNFLG1CQUFtQjtFQUNuQixrQ0FBa0M7RUFDbEMsMEJBQTBCO0VBQzFCLFlBQVk7RUFDWiwySUFBMkk7RUFDM0ksYUFBYTtFQUNiLHNCQUFzQjtFQUN0QixPQUFPO0VBQ1AsVUFBVTtFQUNWLGVBQWU7RUFDZixlQUFlO0VBQ2YsUUFBUTtFQUNSLE1BQU07RUFDTix3Q0FBd0M7RUFDeEMsNEJBQTRCO0VBQzVCLDBDQUEwQztFQUMxQyxXQUFXO0FBQ2I7QUFDQTtFQUNFLDJDQUEyQztFQUMzQyxrQkFBa0I7RUFDbEIsZ0JBQWdCO0VBQ2hCLGlCQUFpQjtFQUNqQixrQkFBa0I7RUFDbEIsa0JBQWtCO0VBQ2xCLFlBQVk7QUFDZDtBQUNBO0VBQ0UsNkJBQTZCO0VBQzdCLG1CQUFtQjtFQUNuQixtQkFBbUI7RUFDbkIsZUFBZTtFQUNmLGdCQUFnQjtFQUNoQixjQUFjO0VBQ2QsaUJBQWlCO0VBQ2pCLGdCQUFnQjtFQUNoQixhQUFhO0VBQ2IsdUJBQXVCO0VBQ3ZCLFdBQVc7QUFDYjtBQUNBO0VBQ0UsOEJBQThCO0VBQzlCLFVBQVU7QUFDWjtBQUhBO0VBQ0UsOEJBQThCO0VBQzlCLFVBQVU7QUFDWjtBQUhBO0VBQ0UsOEJBQThCO0VBQzlCLFVBQVU7QUFDWjtBQUNBO0VBQ0UsYUFBYTtFQUNiLFNBQVM7RUFDVCxRQUFRO0FBQ1Y7QUFDQTtFQUNFLGFBQWE7RUFDYixTQUFTO0VBQ1QsUUFBUTtBQUNWO0FBQ0E7Ozs7RUFJRSxhQUFhO0FBQ2Y7QUFDQTtFQUNFLHdCQUF3QjtFQUN4QixrQkFBa0I7RUFDbEIsYUFBYTtFQUNiLFlBQVk7QUFDZDtBQUNBO0VBQ0UseUJBQXlCO0VBQ3pCLFlBQVk7RUFDWixvQkFBb0I7RUFDcEIsV0FBVztBQUNiO0FBQ0E7RUFDRSxxQkFBcUI7RUFDckIsWUFBWTtBQUNkO0FBQ0E7RUFDRSxrQkFBa0I7RUFDbEIsZ0JBQWdCO0FBQ2xCO0FBQ0E7RUFDRSxtQkFBbUI7QUFDckI7QUFDQTtFQUVFLG1CQUFtQjtFQUNuQix5QkFBeUI7RUFDekIseUJBQXlCO0VBSXpCLGFBQWE7RUFDYixzQkFBc0I7RUFHdEIsOEJBQThCO0VBQzlCLG1CQUFtQjtBQUNyQjtBQUNBO0VBQ0UsbUJBQW1CO0FBQ3JCO0FBQ0E7O0VBRUUsK0JBQStCO0VBQy9CLGdCQUFnQjtFQUNoQixzQkFBc0I7QUFDeEI7QUFDQTtFQUNFLG1CQUFtQjtFQUNuQixlQUFlO0VBQ2YsaUJBQWlCO0VBQ2pCLFlBQVk7RUFDWixxQkFBcUI7QUFDdkI7QUFDQTtFQUNFLHlCQUF5QjtFQUl6QixhQUFhO0VBR2IsOEJBQThCO0VBQzlCLFlBQVk7QUFDZDtBQUNBO0VBRUUsbUJBQW1CO0VBQ25CLGtCQUFrQjtFQUNsQix5QkFBeUI7RUFDekIsdUJBQXVCO0VBSXZCLGFBQWE7RUFDYixzQkFBc0I7RUFDdEIsZ0JBQWdCO0VBQ2hCLGlCQUFpQjtFQUNqQixZQUFZO0VBQ1osaUJBQWlCO0VBQ2pCLHFCQUFxQjtFQUVyQixpRkFBaUY7QUFDbkY7QUFDQTtFQUNFLDBDQUEwQztFQUMxQyxvQ0FBb0M7RUFDcEMsbUJBQW1CO0VBQ25CLGlCQUFpQjtFQUNqQixtQkFBbUI7RUFDbkIsa0JBQWtCO0FBQ3BCO0FBQ0E7RUFDRSw4QkFBOEI7RUFDOUIsVUFBVTtBQUNaO0FBQ0E7RUFDRSwwQ0FBMEM7RUFDMUMsb0NBQW9DO0VBQ3BDLGtCQUFrQjtFQUNsQixtQkFBbUI7RUFDbkIsaUJBQWlCO0VBQ2pCLG1CQUFtQjtFQUNuQixxQkFBcUI7RUFDckIscUJBQXFCO0VBQ3JCLGFBQWE7RUFDYixxQkFBcUI7RUFFckIsa0NBQWtDO0VBQ2xDLFdBQVc7QUFDYjtBQUNBO0VBQ0UsMEJBQTBCO0FBQzVCO0FBQ0E7RUFDRSxtQkFBbUI7RUFDbkIsZ0JBQWdCO0VBQ2hCLGlCQUFpQjtFQUNqQixnQkFBZ0I7RUFDaEIsYUFBYTtBQUNmO0FBQ0E7RUFDRSxnQkFBZ0I7RUFDaEIsaUJBQWlCO0VBQ2pCLFlBQVk7RUFDWixvQkFBb0I7QUFDdEI7QUFDQTs7RUFFRSxtQkFBbUI7QUFDckI7QUFDQTtFQUNFLDBDQUEwQztFQUMxQyxvQ0FBb0M7RUFDcEMsa0JBQWtCO0VBQ2xCLG1CQUFtQjtFQUNuQixpQkFBaUI7RUFDakIsWUFBWTtFQUNaLGFBQWE7RUFDYixZQUFZO0VBQ1osVUFBVTtFQUNWLGVBQWU7RUFDZixrQkFBa0I7RUFDbEIsYUFBYTtFQUNiLFdBQVc7RUFDWCxXQUFXO0FBQ2I7QUFDQTtFQUNFLDhCQUE4QjtFQUM5QixVQUFVO0FBQ1o7QUFDQTtFQUNFLHdCQUF3QjtFQUN4QixrQkFBa0I7RUFDbEIsMklBQTJJO0VBQzNJLFVBQVU7RUFDVix3QkFBd0I7RUFDeEIsa0JBQWtCO0VBQ2xCLDJCQUEyQjtBQUM3QjtBQUNBO0VBQ0UsbUNBQW1DO0VBQ25DLGVBQWU7RUFDZixnQkFBZ0I7RUFDaEIsa0JBQWtCO0FBQ3BCO0FBQ0E7RUFDRSxTQUFTO0FBQ1g7QUFDQTtFQUNFLFlBQVk7RUFDWixjQUFjO0VBQ2QsaUJBQWlCO0VBQ2pCLGtCQUFrQjtFQUNsQixXQUFXO0VBQ1gsVUFBVTtBQUNaO0FBQ0E7RUFDRSxZQUFZO0VBQ1osV0FBVztBQUNiO0FBQ0E7RUFDRSxnQ0FBZ0M7QUFDbEM7QUFDQTtFQUNFLHVCQUF1QjtFQUN2QixnQkFBZ0I7RUFDaEIsWUFBWTtFQUNaLHFCQUFxQjtFQUNyQixrQkFBa0I7QUFDcEI7QUFDQTtFQUNFLGtCQUFrQjtFQUNsQix1QkFBdUI7RUFDdkIscUJBQXFCO0VBQ3JCLGdCQUFnQjtFQUNoQixZQUFZO0VBQ1osaUJBQWlCO0VBQ2pCLHFCQUFxQjtFQUNyQixxQ0FBcUM7RUFDckMscURBQXFEO0VBQ3JELDRDQUE0QztBQUM5QztBQUNBO0VBQ0UsbUJBQW1CO0VBQ25CLG1DQUFtQztFQUNuQyxVQUFVO0FBQ1o7QUFDQTtFQUNFLHFCQUFxQjtBQUN2QjtBQUNBO0VBQ0UsaUJBQWlCO0FBQ25CO0FBQ0E7RUFDRSxXQUFXO0VBQ1gsZUFBZTtFQUNmLHFCQUFxQjtFQUNyQixpQkFBaUI7RUFDakIsa0JBQWtCO0VBQ2xCLGVBQWU7RUFDZixxQkFBcUI7RUFDckIsa0JBQWtCO0VBQ2xCLGdCQUFnQjtFQUNoQixxQkFBcUI7RUFDckIseUJBQXlCO0VBQ3pCLHNCQUFzQjtFQUN0QixxQkFBcUI7RUFDckIsaUJBQWlCO0VBQ2pCLG1CQUFtQjtFQUNuQixtQkFBbUI7QUFDckI7QUFDQTtFQUNFLHNCQUFzQjtFQUN0QixZQUFZO0VBQ1osd0JBQXdCO0VBQ3hCLHFCQUFxQjtFQUNyQix5QkFBeUI7RUFDekIseUJBQXlCO0VBQ3pCLGdDQUFnQztFQUNoQyxXQUFXO0FBQ2I7QUFDQTtFQUNFLHlCQUF5QjtFQUN6QixtQ0FBbUM7RUFDbkMsVUFBVTtBQUNaO0FBQ0E7RUFDRSxrQ0FBa0M7QUFDcEM7QUFDQTtFQUNFLG1CQUFtQjtFQUNuQixrQkFBa0I7RUFDbEIsV0FBVztFQUNYLGFBQWE7RUFDYixnQkFBZ0I7RUFDaEIsWUFBWTtFQUNaLGlCQUFpQjtFQUNqQixxQ0FBcUM7RUFDckMscURBQXFEO0VBQ3JELDRDQUE0QztBQUM5QztBQUNBO0VBQ0UsYUFBYTtFQUNiLGtCQUFrQjtFQUNsQixRQUFRO0FBQ1Y7QUFDQTtFQUNFLDhCQUE4QjtFQUM5QixrQkFBa0I7RUFDbEIsK0NBQStDO0VBQy9DLGFBQWE7RUFDYixzQkFBc0I7RUFDdEIsaUNBQWlDO0VBQ2pDLGNBQWM7QUFDaEI7QUFDQTtFQUNFLHdCQUF1QjtVQUF2Qix1QkFBdUI7QUFDekI7QUFDQTtFQUNFLG1CQUFtQjtFQUNuQixrQkFBa0I7RUFDbEIsYUFBYTtFQUNiLGdCQUFnQjtFQUNoQixxQkFBcUI7RUFDckIsdUNBQXVDO0FBQ3pDO0FBQ0E7RUFDRSx5QkFBeUI7QUFDM0I7QUFDQTtFQUNFLHlCQUF5QjtBQUMzQjtBQUNBO0VBQ0UseUJBQXlCO0FBQzNCO0FBQ0E7RUFDRSx1QkFBdUI7RUFDdkIsV0FBVztBQUNiO0FBQ0E7RUFDRSx1QkFBdUI7RUFDdkIscUJBQXFCO0FBQ3ZCO0FBQ0E7RUFDRSx1QkFBdUI7RUFDdkIscUJBQXFCO0FBQ3ZCO0FBQ0E7RUFDRSx1QkFBdUI7RUFDdkIscUJBQXFCO0FBQ3ZCO0FBQ0E7RUFDRSx1QkFBdUI7RUFDdkIscUJBQXFCO0FBQ3ZCO0FBQ0E7RUFDRSx1QkFBdUI7QUFDekI7QUFDQTtFQUNFLGNBQWM7QUFDaEI7QUFDQTtFQUNFLGl3QkFBaXdCO0VBQ2p3Qix1QkFBdUI7QUFDekI7QUFDQTtFQUNFLGNBQWM7QUFDaEI7QUFDQTtFQUNFLGtCQUFrQjtFQUNsQixxQkFBcUI7RUFDckIsbUJBQW1CO0VBQ25CLGVBQWU7RUFDZixZQUFZO0VBQ1osa0JBQWtCO0VBQ2xCLHFDQUFxQztFQUNyQyxzREFBc0Q7RUFDdEQsNENBQTRDO0FBQzlDO0FBQ0E7RUFDRSxjQUFjO0VBQ2Qsd0JBQXdCO0VBQ3hCLHlCQUF5QjtFQUN6QiwyQkFBMkI7RUFDM0IsZ0NBQWdDO0VBQ2hDLGFBQWE7QUFDZjtBQUNBO0VBQ0UseUJBQXlCO0VBQ3pCLFVBQVU7QUFDWjtBQUNBO0VBQ0Usb0NBQW9DO0FBQ3RDO0FBQ0E7O0VBRUUsaUNBQWlDO0VBQ2pDLGtCQUFrQjtFQUNsQixtQkFBbUI7RUFDbkIsZUFBZTtFQUNmLGdCQUFnQjtFQUNoQixtQkFBbUI7RUFDbkIsaUJBQWlCO0VBQ2pCLG9CQUFvQjtFQUNwQixrQkFBa0I7RUFDbEIscUJBQXFCO0VBQ3JCLG1CQUFtQjtBQUNyQjtBQUNBOztFQUVFLCtDQUErQztBQUNqRDtBQUNBO0VBQ0UsWUFBWTtFQUNaLGNBQWM7RUFDZCxpQkFBaUI7RUFDakIsVUFBVTtFQUNWLFdBQVc7QUFDYjtBQUNBO0VBQ0UsWUFBWTtFQUNaLDhCQUE4QjtFQUM5QixpQkFBaUI7RUFDakIsV0FBVztBQUNiO0FBQ0E7RUFDRSxrQkFBa0I7RUFDbEIsYUFBYTtBQUNmO0FBQ0E7RUFDRSxZQUFZO0VBQ1osV0FBVztBQUNiO0FBQ0E7RUFDRSxtQkFBbUI7QUFDckI7QUFDQTtFQUNFLHlCQUF5QjtBQUMzQjtBQUNBO0VBQ0U7SUFDRSxhQUFhO0lBQ2Isc0JBQXNCO0lBQ3RCLGFBQWE7SUFDYixPQUFPO0lBQ1AsZ0JBQWdCO0lBQ2hCLHNCQUFzQjtJQUN0QixrQkFBa0I7SUFDbEIsUUFBUTtJQUNSLE1BQU07SUFDTiwrR0FBK0c7SUFDL0csNEJBQTRCO0lBQzVCLFdBQVc7RUFDYjtBQUNGO0FBQ0E7RUFDRSxvQkFBb0I7RUFDcEIsOEJBQThCO0VBQzlCLGlCQUFpQjtBQUNuQjtBQUNBO0VBQ0UsYUFBYTtBQUNmO0FBQ0E7RUFDRSxlQUFlO0VBQ2YsaUJBQWlCO0FBQ25CO0FBQ0E7RUFDRSxhQUFhO0FBQ2Y7QUFDQTtFQUNFLGNBQWM7QUFDaEI7QUFDQTtFQUNFLGFBQWE7QUFDZjtBQUNBO0VBQ0U7SUFDRSxnQkFBZ0I7SUFDaEIsZUFBZTtJQUNmLFlBQVk7SUFDWixhQUFhO0lBQ2IsVUFBVTtJQUNWLGdCQUFnQjtJQUNoQixVQUFVO0lBQ1YsZ0JBQWdCO0lBQ2hCLGVBQWU7SUFDZiwwREFBMEQ7SUFDMUQsbUJBQW1CO0VBQ3JCO0VBQ0E7SUFDRSxhQUFhO0lBQ2Isc0JBQXNCO0VBQ3hCO0VBQ0E7SUFDRSxhQUFhO0lBQ2Isc0JBQXNCO0lBQ3RCLG1CQUF3QjtJQUF4Qix3QkFBd0I7SUFDeEIsb0JBQW9CO0lBQ3BCLG1CQUFtQjtFQUNyQjtFQUNBO0lBQ0UsZUFBZTtJQUNmLGdCQUFnQjtJQUNoQixvQkFBb0I7RUFDdEI7RUFDQTtJQUNFLHNCQUFzQjtFQUN4QjtFQUNBO0lBQ0UsdUNBQXVDO0lBQ3ZDLGVBQWU7SUFDZixrQkFBa0I7RUFDcEI7RUFDQTtJQUNFLGFBQWE7SUFDYixlQUFlO0VBQ2pCO0VBQ0E7SUFDRSxhQUFhO0lBQ2IsY0FBYztJQUNkLDJCQUEyQjtJQUMzQixVQUFVO0VBQ1o7RUFDQTtJQUNFLGFBQWE7SUFDYixTQUFTO0VBQ1g7RUFDQTtJQUNFLFdBQVc7RUFDYjtFQUNBO0lBQ0Usa0NBQWtDO0VBQ3BDO0VBQ0E7SUFDRSxXQUFXO0VBQ2I7RUFDQTtJQUNFLHVCQUF1QjtJQUN2QixXQUFXO0VBQ2I7QUFDRjtBQUNBO0VBQ0U7SUFDRSxlQUFlO0lBQ2YsOEJBQThCO0lBQzlCLGtCQUFrQjtFQUNwQjtFQUNBO0lBQ0UsZ0JBQWdCO0VBQ2xCO0VBQ0E7SUFDRSx1QkFBdUI7SUFDdkIsZUFBZTtJQUNmLFVBQVU7RUFDWjtBQUNGO0FBQ0E7RUFDRTtJQUNFLDhCQUE4QjtJQUM5Qix5Q0FBeUM7SUFDekMsY0FBYztJQUNkLFlBQVk7SUFDWix1QkFBdUI7SUFDdkIsa0JBQWtCO0lBQ2xCLFVBQVU7RUFDWjtFQUNBO0lBQ0UsWUFBWTtJQUNaLGlCQUFpQjtJQUNqQixrQkFBa0I7SUFDbEIsaUJBQWlCO0lBQ2pCLFdBQVc7RUFDYjtFQUNBO0lBQ0UsZUFBZTtFQUNqQjtFQUNBO0lBQ0UsY0FBYztJQUNkLGFBQWE7RUFDZjtFQUNBO0lBQ0UsWUFBWTtFQUNkO0VBQ0E7SUFDRSxtQkFBbUI7RUFDckI7RUFDQTtJQUNFLGFBQWE7RUFDZjtFQUNBO0lBQ0UscUJBQXFCO0VBQ3ZCO0VBQ0E7SUFDRSxpQkFBaUI7RUFDbkI7RUFDQTtJQUNFLFdBQVc7SUFDWCxlQUFlO0lBQ2YscUJBQXFCO0lBQ3JCLGlCQUFpQjtJQUNqQixrQkFBa0I7SUFDbEIsZUFBZTtJQUNmLHFCQUFxQjtJQUNyQixrQkFBa0I7SUFDbEIsZ0JBQWdCO0lBQ2hCLHFCQUFxQjtJQUNyQix5QkFBeUI7SUFDekIsc0JBQXNCO0lBQ3RCLHFCQUFxQjtJQUNyQixpQkFBaUI7SUFDakIsbUJBQW1CO0lBQ25CLG1CQUFtQjtFQUNyQjtFQUNBO0lBQ0Usc0JBQXNCO0lBQ3RCLFlBQVk7SUFDWix3QkFBd0I7SUFDeEIscUJBQXFCO0lBQ3JCLHdCQUF3QjtJQUN4Qix5QkFBeUI7SUFDekIsZ0NBQWdDO0lBQ2hDLFdBQVc7RUFDYjtFQUNBO0lBQ0UseUJBQXlCO0lBQ3pCLG1DQUFtQztJQUNuQyxVQUFVO0VBQ1o7RUFDQTtJQUNFLGtDQUFrQztFQUNwQztFQUNBO0lBQ0UsbUJBQW1CO0lBQ25CLGtCQUFrQjtJQUNsQixXQUFXO0lBQ1gsYUFBYTtJQUNiLGdCQUFnQjtJQUNoQixZQUFZO0lBQ1osaUJBQWlCO0lBQ2pCLHFDQUFxQztJQUNyQyxxREFBcUQ7SUFDckQsNENBQTRDO0VBQzlDO0VBQ0E7SUFDRSxhQUFhO0lBQ2Isa0JBQWtCO0lBQ2xCLFFBQVE7RUFDVjtFQUNBO0lBQ0UsOEJBQThCO0lBQzlCLGtCQUFrQjtJQUNsQiwrQ0FBK0M7SUFDL0MsYUFBYTtJQUNiLHNCQUFzQjtJQUN0QixpQ0FBaUM7SUFDakMsY0FBYztFQUNoQjtFQUNBO0lBQ0Usd0JBQXVCO1lBQXZCLHVCQUF1QjtFQUN6QjtFQUNBO0lBQ0UsbUJBQW1CO0lBQ25CLGtCQUFrQjtJQUNsQixhQUFhO0lBQ2IsZ0JBQWdCO0lBQ2hCLHFCQUFxQjtJQUNyQix1Q0FBdUM7RUFDekM7RUFDQTtJQUNFLHlCQUF5QjtFQUMzQjtFQUNBO0lBQ0UseUJBQXlCO0VBQzNCO0VBQ0E7SUFDRSx5QkFBeUI7RUFDM0I7RUFDQTtJQUNFLHVCQUF1QjtFQUN6QjtFQUNBO0lBQ0UsdUJBQXVCO0lBQ3ZCLHFCQUFxQjtFQUN2QjtFQUNBO0lBQ0UsdUJBQXVCO0lBQ3ZCLHFCQUFxQjtFQUN2QjtFQUNBO0lBQ0UsdUJBQXVCO0lBQ3ZCLHFCQUFxQjtFQUN2QjtFQUNBO0lBQ0UsdUJBQXVCO0lBQ3ZCLHFCQUFxQjtFQUN2QjtFQUNBO0lBQ0UsdUJBQXVCO0VBQ3pCO0VBQ0E7SUFDRSxjQUFjO0VBQ2hCO0VBQ0E7SUFDRSxpd0JBQWl3QjtJQUNqd0IsdUJBQXVCO0VBQ3pCO0VBQ0E7SUFDRSxjQUFjO0VBQ2hCO0VBQ0E7SUFDRSxrQkFBa0I7SUFDbEIscUJBQXFCO0lBQ3JCLG1CQUFtQjtJQUNuQixZQUFZO0lBQ1osa0JBQWtCO0lBQ2xCLHFDQUFxQztJQUNyQyxzREFBc0Q7SUFDdEQsNENBQTRDO0VBQzlDO0VBQ0E7SUFDRSxjQUFjO0lBQ2Qsd0JBQXdCO0lBQ3hCLHlCQUF5QjtJQUN6QiwyQkFBMkI7SUFDM0IsZ0NBQWdDO0lBQ2hDLGFBQWE7RUFDZjtFQUNBO0lBQ0UseUJBQXlCO0lBQ3pCLFVBQVU7RUFDWjtFQUNBO0lBQ0Usb0NBQW9DO0VBQ3RDO0FBQ0Y7QUFDQTtFQUNFO0lBQ0UsWUFBWTtJQUNaLFNBQVM7RUFDWDtFQUNBO0lBQ0UsaUJBQWlCO0lBQ2pCLGtCQUFrQjtFQUNwQjtFQUNBO0lBQ0UsYUFBYTtFQUNmO0VBQ0E7SUFDRSxtQkFBbUI7SUFDbkIsNkJBQTZCO0lBQzdCLFNBQVM7SUFDVCxPQUFPO0lBQ1AsVUFBVTtJQUNWLHNCQUFzQjtJQUN0QixjQUFjO0lBQ2Qsa0JBQWtCO0lBQ2xCLE1BQU07SUFDTixtREFBbUQ7SUFDbkQsa0JBQWtCO0VBQ3BCO0VBQ0E7SUFDRSw4QkFBOEI7SUFDOUIsYUFBYTtJQUNiLFVBQVU7SUFDVixrQkFBa0I7SUFDbEIsTUFBTTtJQUNOLHdCQUF3QjtJQUN4QixtQkFBbUI7SUFDbkIsVUFBVTtFQUNaO0VBQ0E7SUFDRSw4QkFBOEI7SUFDOUIsV0FBVztJQUNYLGFBQWE7SUFDYixZQUFZO0lBQ1osV0FBVztFQUNiO0VBQ0E7SUFDRSx3QkFBd0I7SUFDeEIsYUFBYTtJQUNiLHNCQUFzQjtJQUN0QixpQkFBaUI7SUFDakIsWUFBWTtFQUNkO0VBQ0E7SUFDRSx3QkFBd0I7SUFDeEIscUJBQXFCO0lBQ3JCLGdCQUFnQjtJQUNoQix3QkFBd0I7SUFDeEIsTUFBTTtJQUNOLFdBQVc7SUFDWCxVQUFVO0VBQ1o7RUFDQTtJQUNFLG9CQUFvQjtFQUN0QjtFQUNBO0lBQ0Usa0JBQWtCO0lBQ2xCLGFBQWE7RUFDZjtFQUNBO0lBQ0UsY0FBYztJQUNkLGlDQUFpQztJQUNqQyxXQUFXO0VBQ2I7RUFDQTtJQUNFLGtDQUFrQztFQUNwQztFQUNBO0lBQ0UsYUFBYTtJQUNiLHVCQUF1QjtJQUN2QixXQUFXO0VBQ2I7RUFDQTtJQUNFLDJJQUEySTtJQUMzSSxTQUFTO0lBQ1Qsa0JBQWtCO0lBQ2xCLFdBQVc7RUFDYjtFQUNBO0lBQ0UsOEJBQThCO0lBQzlCLGNBQWM7SUFDZCwyQkFBMkI7SUFDM0IsV0FBVztFQUNiO0VBQ0E7SUFDRSxhQUFhO0lBQ2IsZ0JBQWdCO0lBQ2hCLDhCQUE4QjtJQUM5QixXQUFXO0VBQ2I7RUFDQTtJQUNFLHVCQUF1QjtJQUN2QixlQUFlO0VBQ2pCO0VBQ0E7SUFDRSx3QkFBd0I7SUFDeEIsYUFBYTtJQUNiLHNCQUFzQjtJQUN0QixZQUFZO0VBQ2Q7RUFDQTtJQUNFLHdCQUF3QjtJQUN4QixxQkFBcUI7SUFDckIsV0FBVztFQUNiO0VBQ0E7SUFDRSxrQkFBa0I7RUFDcEI7RUFDQTtJQUNFLGtCQUFrQjtJQUNsQixhQUFhO0VBQ2Y7QUFDRjtBQUNBO0VBQ0U7SUFDRSxlQUFlO0lBQ2YsZUFBZTtJQUNmLFVBQVU7SUFDViw0QkFBNEI7SUFDNUIsVUFBVTtFQUNaO0VBQ0E7SUFDRSxhQUFhO0VBQ2Y7RUFDQTtJQUNFLDhCQUE4QjtJQUM5Qix1Q0FBdUM7SUFDdkMscUJBQXFCO0lBQ3JCLDJJQUEySTtJQUMzSSw0QkFBNEI7SUFDNUIsY0FBYztJQUNkLG1CQUFtQjtJQUNuQixnQkFBZ0I7SUFDaEIsb0JBQW9CO0lBQ3BCLGtCQUFrQjtJQUNsQixxQkFBcUI7SUFDckIsYUFBYTtFQUNmO0FBQ0Y7QUFDQTtFQUNFO0lBQ0UsZ0JBQWdCO0lBQ2hCLGVBQWU7SUFDZixZQUFZO0lBQ1osU0FBUztJQUNULGFBQWE7SUFDYixVQUFVO0lBQ1YsVUFBVTtJQUNWLGdCQUFnQjtJQUNoQixlQUFlO0lBQ2YsMERBQTBEO0lBQzFELG1CQUFtQjtFQUNyQjtFQUNBO0lBQ0UsYUFBYTtJQUNiLHNCQUFzQjtFQUN4QjtFQUNBO0lBQ0UsbUJBQXdCO0lBQXhCLHdCQUF3QjtJQUN4QixhQUFhO0VBQ2Y7RUFDQTtJQUNFLHVCQUF5QjtRQUF6Qix5QkFBeUI7RUFDM0I7RUFDQTtJQUNFLHVCQUF1QjtJQUN2Qix1QkFBeUI7UUFBekIseUJBQXlCO0VBQzNCO0VBQ0E7SUFDRSx1QkFBdUI7SUFDdkIsdUJBQXlCO1FBQXpCLHlCQUF5QjtFQUMzQjtFQUNBO0lBQ0UsVUFBVTtFQUNaO0VBQ0E7SUFDRSxvQkFBb0I7SUFDcEIsbUJBQW1CO0lBQ25CLGtCQUFrQjtFQUNwQjtFQUNBO0lBQ0Usb0JBQW9CO0VBQ3RCO0VBQ0E7SUFDRSxZQUFZO0VBQ2Q7RUFDQTtJQUNFLG1CQUFtQjtJQUNuQiw2QkFBNkI7SUFDN0IsU0FBUztJQUNULE9BQU87SUFDUCxVQUFVO0lBQ1YsaUJBQWlCO0lBQ2pCLGNBQWM7SUFDZCxrQkFBa0I7SUFDbEIsTUFBTTtJQUNOLG1EQUFtRDtJQUNuRCxrQkFBa0I7SUFDbEIsV0FBVztFQUNiO0VBQ0E7SUFDRSw4QkFBOEI7SUFDOUIsYUFBYTtJQUNiLFVBQVU7SUFDVixjQUFjO0lBQ2QsU0FBUztJQUNULHdCQUF3QjtJQUN4QixtQkFBbUI7RUFDckI7RUFDQTs7SUFFRSxhQUFhO0VBQ2Y7RUFDQTtJQUNFLHdCQUF3QjtJQUN4QixhQUFhO0lBQ2Isc0JBQXNCO0lBQ3RCLGtDQUFrQztJQUNsQyxjQUFjO0VBQ2hCO0VBQ0E7SUFDRSxzQkFBc0I7SUFDdEIsZ0JBQWdCO0lBQ2hCLHdCQUF3QjtJQUN4QixNQUFNO0lBQ04sV0FBVztJQUNYLFVBQVU7RUFDWjtFQUNBO0lBQ0Usa0JBQWtCO0VBQ3BCO0VBQ0E7SUFDRSxrQkFBa0I7SUFDbEIsYUFBYTtFQUNmO0VBQ0E7SUFDRSxhQUFhO0lBQ2IscUJBQXFCO0lBQ3JCLGtCQUFrQjtJQUNsQixRQUFRO0lBQ1IsVUFBVTtFQUNaO0VBQ0E7SUFDRSxxQkFBcUI7SUFDckIsY0FBYztJQUNkLGtCQUFrQjtJQUNsQixTQUFTO0VBQ1g7RUFDQTtJQUNFLHVDQUF1QztJQUN2QyxrQkFBa0I7SUFDbEIsNEJBQTRCO0lBQzVCLHFCQUFxQjtJQUNyQixlQUFlO0lBQ2YsZ0JBQWdCO0lBQ2hCLGlCQUFpQjtJQUNqQixxQkFBcUI7SUFDckIsVUFBVTtFQUNaO0VBQ0E7SUFDRSxvQkFBb0I7RUFDdEI7RUFDQTtJQUNFLG9CQUFvQjtFQUN0QjtFQUNBO0lBQ0UsZUFBZTtFQUNqQjtBQUNGO0FBQ0E7RUFDRTtJQUNFLHlDQUF5QztFQUMzQztFQUNBO0lBQ0UsY0FBYztFQUNoQjtFQUNBO0lBQ0Usb0NBQW9DO0VBQ3RDO0VBQ0E7SUFDRSxjQUFjO0lBQ2QsVUFBVTtFQUNaO0VBQ0E7SUFDRSxlQUFlO0VBQ2pCO0VBQ0E7SUFDRSxtQkFBbUI7SUFDbkIsYUFBYTtJQUNiLFVBQVU7RUFDWjtFQUNBO0lBQ0UsT0FBTztJQUNQLFdBQVc7RUFDYjtFQUNBO0lBQ0Usa0JBQWtCO0lBQ2xCLFVBQVU7RUFDWjtFQUNBO0lBQ0UsZUFBZTtJQUNmLG1CQUFtQjtJQUNuQixtQ0FBbUM7SUFDbkMsa0JBQWtCO0VBQ3BCO0VBQ0E7SUFDRSxhQUFhO0VBQ2Y7RUFDQTtJQUNFLG1CQUFtQjtJQUNuQixZQUFZO0lBQ1osV0FBVztJQUNYLFdBQVc7SUFDWCxTQUFTO0lBQ1Qsa0JBQWtCO0lBQ2xCLGlEQUFpRDtJQUNqRCxTQUFTO0VBQ1g7RUFDQTtJQUNFLGdDQUFnQztJQUNoQyw2SUFBNkk7SUFDN0ksb0JBQW9CO0VBQ3RCO0VBQ0E7SUFDRSxhQUFhO0VBQ2Y7RUFDQTtJQUNFLGFBQWE7RUFDZjtBQUNGOztBQUVBO0VBQ0Usa0NBQWtDO0VBQ2xDLG1CQUFtQjtFQUNuQixZQUFZO0FBQ2Q7QUFDQTtFQUNFO0lBQ0UsY0FBYztFQUNoQjtBQUNGO0FBQ0E7RUFDRSxjQUFjO0VBQ2QsaUJBQWlCO0VBQ2pCLHlCQUF5QjtBQUMzQjtBQUNBO0VBQ0UsU0FBUztFQUNULFVBQVU7QUFDWjtBQUNBO0VBQ0UsaUJBQWlCO0VBQ2pCLGdCQUFnQjtFQUNoQixTQUFTO0FBQ1g7QUFDQTtFQUNFLG1CQUFtQjtFQUNuQixrQkFBa0I7RUFDbEIsU0FBUztFQUNULGdCQUFnQjtBQUNsQjtBQUNBO0VBQ0UsY0FBYztBQUNoQjtBQUNBO0VBQ0UscUJBQXFCO0FBQ3ZCO0FBQ0E7RUFJRSxzQkFBc0I7RUFDdEIsaUJBQWlCO0VBQ2pCLGNBQWM7QUFDaEI7QUFDQTtFQUNFO0lBQ0UsbUJBQW1CO0VBQ3JCO0FBQ0Y7QUFDQTtFQUVFLE9BQU87QUFDVDtBQUNBO0VBQ0Usc0JBQXNCO0VBQ3RCLFNBQVM7RUFDVCxxQkFBcUI7RUFDckIseUJBQXlCO0VBQ3pCLHNCQUFzQjtFQUN0QixxQkFBcUI7RUFDckIsaUJBQWlCO0FBQ25CO0FBQ0E7RUFDRTtJQUNFLGlCQUFpQjtFQUNuQjtBQUNGO0FBQ0E7RUFDRSxhQUFhO0FBQ2Y7QUFDQTtFQUNFLFlBQVk7RUFDWixVQUFVO0VBQ1YsaUJBQWlCO0VBQ2pCLGNBQWM7RUFDZCxtQkFBbUI7QUFDckI7QUFDQTtFQUNFLG1CQUFtQjtFQUNuQix1QkFBdUI7QUFDekI7QUFDQTtFQUNFLHdCQUF3QjtFQUN4QixxQkFBcUI7RUFFckIsMklBQTJJO0VBRTNJLHNCQUFzQjtFQUN0QixTQUFTO0VBQ1QsY0FBYztFQUNkLFVBQVU7RUFDVixnQkFBZ0I7RUFDaEIsVUFBVTtFQUNWLGtCQUFrQjtFQUVsQiw0QkFBNEI7RUFFNUIsMkdBQTJHO0VBQzNHLGtCQUFrQjtFQUNsQixtQkFBbUI7RUFDbkIsYUFBYTtBQUNmO0FBQ0E7RUFDRSx3QkFBd0I7RUFDeEIseUJBQXlCO0VBQ3pCLFlBQVk7RUFDWixXQUFXO0VBQ1gsWUFBWTtFQUNaLFNBQVM7RUFDVCxrQkFBa0I7RUFFbEIsd0JBQXdCO0VBRXhCLHNEQUFzRDtFQUN0RCxXQUFXO0FBQ2I7QUFDQTtFQUNFLHlCQUF5QjtBQUMzQjtBQUNBO0VBQ0UsT0FBTztBQUNUO0FBQ0E7RUFDRSxtQkFBbUI7RUFDbkIseUJBQXlCO0VBQ3pCLGVBQWU7RUFHZixhQUFhO0VBQ2Isc0JBQXNCO0FBQ3hCO0FBQ0E7RUFDRSxpQkFBaUI7RUFDakIsZ0JBQWdCO0VBQ2hCLG1CQUFtQjtBQUNyQjtBQUNBO0VBQ0UsZUFBZTtBQUNqQjtBQUNBO0VBQ0UsbUJBQW1CO0VBQ25CLGdCQUFnQjtFQUNoQixtQkFBbUI7QUFDckI7QUFDQTtFQUNFLHVCQUF1QjtBQUN6QjtBQUNBO0VBQ0Usc0JBQXNCO0VBQ3RCLGdCQUFnQjtFQUNoQixXQUFXO0FBQ2I7QUFDQTtFQUNFO0lBQ0UsY0FBYztFQUNoQjtBQUNGO0FBQ0E7RUFDRTtJQUNFLGtCQUFrQjtFQUNwQjtBQUNGO0FBQ0E7RUFDRTtJQUNFLGtCQUFrQjtFQUNwQjtBQUNGO0FBQ0E7RUFDRSxxQkFBcUI7RUFDckIsZ0JBQWdCO0VBQ2hCLG1CQUFtQjtFQUNuQixnQkFBZ0I7RUFDaEIseUJBQXlCO0FBQzNCO0FBQ0E7RUFHRSxPQUFPO0VBQ1AsZ0JBQWdCO0FBQ2xCO0FBQ0E7RUFDRTtJQUNFLGNBQWM7RUFDaEI7QUFDRjtBQUNBO0VBQ0UsaUJBQWlCO0VBQ2pCLGtCQUFrQjtFQUNsQixtQkFBbUI7RUFDbkIsb0JBQW9CO0FBQ3RCO0FBQ0E7RUFDRTtJQUNFLGNBQWM7RUFDaEI7QUFDRjtBQUNBO0VBQ0UsbUJBQW1CO0VBQ25CLGNBQWM7QUFDaEI7QUFDQTtFQUNFLHFCQUFxQjtFQUNyQixrQkFBa0I7RUFDbEIsY0FBYztFQUNkLGFBQWE7RUFFYixpQ0FBaUM7RUFDakMsYUFBYTtBQUNmO0FBQ0E7RUFDRSxtQkFBbUI7RUFDbkIsZ0JBQWdCO0FBQ2xCO0FBQ0E7RUFDRTtJQUNFLGlCQUFpQjtFQUNuQjtBQUNGO0FBQ0E7RUFDRSxtQkFBbUI7RUFDbkIsZUFBZTtFQUNmLGtCQUFrQjtFQUNsQixTQUFTO0VBQ1QsZ0JBQWdCO0FBQ2xCO0FBQ0E7RUFDRSxrQkFBa0I7QUFDcEI7QUFDQTtFQUNFLGtDQUFrQztFQUNsQyxzQkFBc0I7RUFDdEIsdUJBQXVCO0VBQ3ZCLGFBQWE7RUFDYixlQUFlO0VBQ2Ysa0JBQWtCO0VBQ2xCLGdCQUFnQjtBQUNsQjtBQUNBO0VBQ0UsdUJBQXVCO0VBQ3ZCLGdCQUFnQjtFQUNoQixXQUFXO0FBQ2I7QUFDQTtFQUNFO0lBQ0UsY0FBYztFQUNoQjtBQUNGO0FBQ0E7RUFDRSxtQkFBbUI7QUFDckI7QUFDQTtFQUNFLGdCQUFnQjtFQUNoQixXQUFXO0FBQ2I7QUFDQTtFQUNFO0lBQ0UsY0FBYztFQUNoQjtBQUNGOztBQUVBOzs7RUFHRSxhQUFhO0FBQ2YiLCJmaWxlIjoib3NiLWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIi5jb2xvci10cmFuc3BhcmVudCB7XG4gIGNvbG9yOiBcInRyYW5zcGFyZW50XCI7XG59XG5cbi5iZy10cmFuc3BhcmVudCB7XG4gIGJhY2tncm91bmQtY29sb3I6IFwidHJhbnNwYXJlbnRcIjtcbn1cblxuLmNvbG9yLWJsYWNrIHtcbiAgY29sb3I6IHZhcigtLWJsYWNrKTtcbn1cblxuLmJnLWJsYWNrIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tYmxhY2spO1xufVxuXG4uY29sb3ItcHJpbWFyeSB7XG4gIGNvbG9yOiB2YXIoLS1wcmltYXJ5KTtcbn1cblxuLmJnLXByaW1hcnkge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1wcmltYXJ5KTtcbn1cblxuLmNvbG9yLXByaW1hcnktMTAge1xuICBjb2xvcjogdmFyKC0tcHJpbWFyeS0xMCk7XG59XG5cbi5iZy1wcmltYXJ5LTEwIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tcHJpbWFyeS0xMCk7XG59XG5cbi5jb2xvci1wcmltYXJ5LTUge1xuICBjb2xvcjogdmFyKC0tcHJpbWFyeS01KTtcbn1cblxuLmJnLXByaW1hcnktNSB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLXByaW1hcnktNSk7XG59XG5cbi5jb2xvci1wcmltYXJ5LTcge1xuICBjb2xvcjogdmFyKC0tcHJpbWFyeS03KTtcbn1cblxuLmJnLXByaW1hcnktNyB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLXByaW1hcnktNyk7XG59XG5cbi5jb2xvci1wcmltYXJ5LWRhcmsge1xuICBjb2xvcjogdmFyKC0tcHJpbWFyeS1kYXJrKTtcbn1cblxuLmJnLXByaW1hcnktZGFyayB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLXByaW1hcnktZGFyayk7XG59XG5cbi5jb2xvci13aGl0ZSB7XG4gIGNvbG9yOiB2YXIoLS13aGl0ZSk7XG59XG5cbi5iZy13aGl0ZSB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLXdoaXRlKTtcbn1cblxuLmNvbG9yLWFjY2VudC0xIHtcbiAgY29sb3I6IHZhcigtLWFjY2VudC0xKTtcbn1cblxuLmJnLWFjY2VudC0xIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tYWNjZW50LTEpO1xufVxuXG4uY29sb3ItYWNjZW50LTIge1xuICBjb2xvcjogdmFyKC0tYWNjZW50LTIpO1xufVxuXG4uYmctYWNjZW50LTIge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1hY2NlbnQtMik7XG59XG5cbi5jb2xvci1hY2NlbnQtMyB7XG4gIGNvbG9yOiB2YXIoLS1hY2NlbnQtMyk7XG59XG5cbi5iZy1hY2NlbnQtMyB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLWFjY2VudC0zKTtcbn1cblxuLmNvbG9yLWFjY2VudC00IHtcbiAgY29sb3I6IHZhcigtLWFjY2VudC00KTtcbn1cblxuLmJnLWFjY2VudC00IHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tYWNjZW50LTQpO1xufVxuXG4uY29sb3ItYWNjZW50LTUge1xuICBjb2xvcjogdmFyKC0tYWNjZW50LTUpO1xufVxuXG4uYmctYWNjZW50LTUge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1hY2NlbnQtNSk7XG59XG5cbi5jb2xvci1hY2NlbnQtNiB7XG4gIGNvbG9yOiB2YXIoLS1hY2NlbnQtNik7XG59XG5cbi5iZy1hY2NlbnQtNiB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLWFjY2VudC02KTtcbn1cblxuLmNvbG9yLWFjY2VudC03IHtcbiAgY29sb3I6IHZhcigtLWFjY2VudC03KTtcbn1cblxuLmJnLWFjY2VudC03IHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tYWNjZW50LTcpO1xufVxuXG4uY29sb3ItYWNjZW50LTgge1xuICBjb2xvcjogdmFyKC0tYWNjZW50LTgpO1xufVxuXG4uYmctYWNjZW50LTgge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1hY2NlbnQtOCk7XG59XG5cbi5jb2xvci1hY2NlbnQtOSB7XG4gIGNvbG9yOiB2YXIoLS1hY2NlbnQtOSk7XG59XG5cbi5iZy1hY2NlbnQtOSB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLWFjY2VudC05KTtcbn1cblxuLmNvbG9yLWFjY2VudC0xMCB7XG4gIGNvbG9yOiB2YXIoLS1hY2NlbnQtMTApO1xufVxuXG4uYmctYWNjZW50LTEwIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tYWNjZW50LTEwKTtcbn1cblxuLmNvbG9yLW5ldXRyYWwtMSB7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTEpO1xufVxuXG4uYmctbmV1dHJhbC0xIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tbmV1dHJhbC0xKTtcbn1cblxuLmNvbG9yLW5ldXRyYWwtMiB7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTIpO1xufVxuXG4uYmctbmV1dHJhbC0yIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tbmV1dHJhbC0yKTtcbn1cblxuLmNvbG9yLW5ldXRyYWwtMyB7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTMpO1xufVxuXG4uYmctbmV1dHJhbC0zIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tbmV1dHJhbC0zKTtcbn1cblxuLmNvbG9yLW5ldXRyYWwtNCB7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTQpO1xufVxuXG4uYmctbmV1dHJhbC00IHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tbmV1dHJhbC00KTtcbn1cblxuLmNvbG9yLW5ldXRyYWwtNSB7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTUpO1xufVxuXG4uYmctbmV1dHJhbC01IHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tbmV1dHJhbC01KTtcbn1cblxuLmNvbG9yLW5ldXRyYWwtNiB7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTYpO1xufVxuXG4uYmctbmV1dHJhbC02IHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tbmV1dHJhbC02KTtcbn1cblxuLmNvbG9yLW5ldXRyYWwtNyB7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTcpO1xufVxuXG4uYmctbmV1dHJhbC03IHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tbmV1dHJhbC03KTtcbn1cblxuLmNvbG9yLW5ldXRyYWwtOCB7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTgpO1xufVxuXG4uYmctbmV1dHJhbC04IHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tbmV1dHJhbC04KTtcbn1cblxuLmNvbG9yLW5ldXRyYWwtOSB7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTkpO1xufVxuXG4uYmctbmV1dHJhbC05IHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tbmV1dHJhbC05KTtcbn1cblxuLmNvbG9yLWFjdGlvbi1kZWZhdWx0IHtcbiAgY29sb3I6IHZhcigtLWFjdGlvbi1kZWZhdWx0KTtcbn1cblxuLmJnLWFjdGlvbi1kZWZhdWx0IHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tYWN0aW9uLWRlZmF1bHQpO1xufVxuXG4uY29sb3ItYWN0aW9uLWRlZmF1bHQtaG92ZXIge1xuICBjb2xvcjogdmFyKC0tYWN0aW9uLWRlZmF1bHQtaG92ZXIpO1xufVxuXG4uYmctYWN0aW9uLWRlZmF1bHQtaG92ZXIge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdC1ob3Zlcik7XG59XG5cbi5jb2xvci1hY3Rpb24tZGVmYXVsdC1hY3RpdmUge1xuICBjb2xvcjogdmFyKC0tYWN0aW9uLWRlZmF1bHQtYWN0aXZlKTtcbn1cblxuLmJnLWFjdGlvbi1kZWZhdWx0LWFjdGl2ZSB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLWFjdGlvbi1kZWZhdWx0LWFjdGl2ZSk7XG59XG5cbi5jb2xvci1hY3Rpb24tc2Vjb25kYXJ5IHtcbiAgY29sb3I6IHZhcigtLWFjdGlvbi1zZWNvbmRhcnkpO1xufVxuXG4uYmctYWN0aW9uLXNlY29uZGFyeSB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLWFjdGlvbi1zZWNvbmRhcnkpO1xufVxuXG4uY29sb3ItYWN0aW9uLXNlY29uZGFyeS1ob3ZlciB7XG4gIGNvbG9yOiB2YXIoLS1hY3Rpb24tc2Vjb25kYXJ5LWhvdmVyKTtcbn1cblxuLmJnLWFjdGlvbi1zZWNvbmRhcnktaG92ZXIge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1hY3Rpb24tc2Vjb25kYXJ5LWhvdmVyKTtcbn1cblxuLmNvbG9yLWFjdGlvbi1zZWNvbmRhcnktYWN0aXZlIHtcbiAgY29sb3I6IHZhcigtLWFjdGlvbi1zZWNvbmRhcnktYWN0aXZlKTtcbn1cblxuLmJnLWFjdGlvbi1zZWNvbmRhcnktYWN0aXZlIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tYWN0aW9uLXNlY29uZGFyeS1hY3RpdmUpO1xufVxuXG4uY29sb3ItYWN0aW9uLXZpc2l0ZWQge1xuICBjb2xvcjogdmFyKC0tYWN0aW9uLXZpc2l0ZWQpO1xufVxuXG4uYmctYWN0aW9uLXZpc2l0ZWQge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1hY3Rpb24tdmlzaXRlZCk7XG59XG5cbi5jb2xvci1mdW5jdGlvbi1lcnJvciB7XG4gIGNvbG9yOiAjZGExNDE0O1xufVxuXG4uYmctZnVuY3Rpb24tZXJyb3Ige1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjZGExNDE0O1xufVxuXG4uY29sb3ItZnVuY3Rpb24tZXJyb3ItYm9yZGVyIHtcbiAgY29sb3I6ICNmNDg5ODk7XG59XG5cbi5iZy1mdW5jdGlvbi1lcnJvci1ib3JkZXIge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjZjQ4OTg5O1xufVxuXG4uY29sb3ItZnVuY3Rpb24tZXJyb3ItYmFja2dyb3VuZCB7XG4gIGNvbG9yOiAjZmVlZmVmO1xufVxuXG4uYmctZnVuY3Rpb24tZXJyb3ItYmFja2dyb3VuZCB7XG4gIGJhY2tncm91bmQtY29sb3I6ICNmZWVmZWY7XG59XG5cbi5jb2xvci1mdW5jdGlvbi13YXJuaW5nIHtcbiAgY29sb3I6ICNiOTUwMDA7XG59XG5cbi5iZy1mdW5jdGlvbi13YXJuaW5nIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogI2I5NTAwMDtcbn1cblxuLmNvbG9yLWZ1bmN0aW9uLXdhcm5pbmctYm9yZGVyIHtcbiAgY29sb3I6ICNmZjhmM2E7XG59XG5cbi5iZy1mdW5jdGlvbi13YXJuaW5nLWJvcmRlciB7XG4gIGJhY2tncm91bmQtY29sb3I6ICNmZjhmM2E7XG59XG5cbi5jb2xvci1mdW5jdGlvbi13YXJuaW5nLWJhY2tncm91bmQge1xuICBjb2xvcjogI2ZmZjRlYztcbn1cblxuLmJnLWZ1bmN0aW9uLXdhcm5pbmctYmFja2dyb3VuZCB7XG4gIGJhY2tncm91bmQtY29sb3I6ICNmZmY0ZWM7XG59XG5cbi5jb2xvci1mdW5jdGlvbi1zdWNjZXNzIHtcbiAgY29sb3I6ICMyODdkM2M7XG59XG5cbi5iZy1mdW5jdGlvbi1zdWNjZXNzIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogIzI4N2QzYztcbn1cblxuLmNvbG9yLWZ1bmN0aW9uLXN1Y2Nlc3MtYm9yZGVyIHtcbiAgY29sb3I6ICM1YWNhNzU7XG59XG5cbi5iZy1mdW5jdGlvbi1zdWNjZXNzLWJvcmRlciB7XG4gIGJhY2tncm91bmQtY29sb3I6ICM1YWNhNzU7XG59XG5cbi5jb2xvci1mdW5jdGlvbi1zdWNjZXNzLWJhY2tncm91bmQge1xuICBjb2xvcjogI2VkZjlmMDtcbn1cblxuLmJnLWZ1bmN0aW9uLXN1Y2Nlc3MtYmFja2dyb3VuZCB7XG4gIGJhY2tncm91bmQtY29sb3I6ICNlZGY5ZjA7XG59XG5cbi5jb2xvci1mdW5jdGlvbi1pbmZvIHtcbiAgY29sb3I6ICM4OWE3ZTA7XG59XG5cbi5iZy1mdW5jdGlvbi1pbmZvIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogIzg5YTdlMDtcbn1cblxuLmNvbG9yLWZ1bmN0aW9uLWluZm8tYm9yZGVyIHtcbiAgY29sb3I6ICM4OWE3ZTA7XG59XG5cbi5iZy1mdW5jdGlvbi1pbmZvLWJvcmRlciB7XG4gIGJhY2tncm91bmQtY29sb3I6ICM4OWE3ZTA7XG59XG5cbi5jb2xvci1mdW5jdGlvbi1pbmZvLWJhY2tncm91bmQge1xuICBjb2xvcjogI2VlZjJmYTtcbn1cblxuLmJnLWZ1bmN0aW9uLWluZm8tYmFja2dyb3VuZCB7XG4gIGJhY2tncm91bmQtY29sb3I6ICNlZWYyZmE7XG59XG5cbi5lbGV2YXRpb24tMSB7XG4gIGJveC1zaGFkb3c6IDBweCAwLjVweCAzLjM1cHggMHB4IHJnYmEoMCwgMCwgMCwgMC4xNCksIDBweCAxcHggMS41cHggMHB4IHJnYmEoMCwgMCwgMCwgMC4wMzIpLCAwcHggMi4zcHggMnB4IC0wLjZweCByZ2JhKDAsIDAsIDAsIDAuMDYpO1xufVxuXG4uZWxldmF0aW9uLTIge1xuICBib3gtc2hhZG93OiAwcHggMC44cHggMy43cHggLTAuMzNweCByZ2JhKDAsIDAsIDAsIDAuMTQpLCAwcHggMnB4IDNweCAwLjE1cHggcmdiYSgwLCAwLCAwLCAwLjAzNCksIDBweCAyLjZweCA0cHggLTAuMnB4IHJnYmEoMCwgMCwgMCwgMC4wNik7XG59XG5cbi5lbGV2YXRpb24tMyB7XG4gIGJveC1zaGFkb3c6IDBweCAxLjFweCA0LjA1cHggLTAuNjZweCByZ2JhKDAsIDAsIDAsIDAuMTQpLCAwcHggM3B4IDQuNXB4IDAuM3B4IHJnYmEoMCwgMCwgMCwgMC4wMzYpLCAwcHggMi45cHggNnB4IDAuMnB4IHJnYmEoMCwgMCwgMCwgMC4wNik7XG59XG5cbi5lbGV2YXRpb24tNCB7XG4gIGJveC1zaGFkb3c6IDBweCAxLjRweCA0LjRweCAtMC45OXB4IHJnYmEoMCwgMCwgMCwgMC4xNCksIDBweCA0cHggNnB4IDAuNDVweCByZ2JhKDAsIDAsIDAsIDAuMDM4KSwgMHB4IDMuMnB4IDhweCAwLjZweCByZ2JhKDAsIDAsIDAsIDAuMDYpO1xufVxuXG4uZWxldmF0aW9uLTUge1xuICBib3gtc2hhZG93OiAwcHggMnB4IDUuMXB4IC0xLjY1cHggcmdiYSgwLCAwLCAwLCAwLjE0KSwgMHB4IDZweCA5cHggMC43NXB4IHJnYmEoMCwgMCwgMCwgMC4wNDIpLCAwcHggMy44cHggMTJweCAxLjRweCByZ2JhKDAsIDAsIDAsIDAuMDYpO1xufVxuXG4uZWxldmF0aW9uLTYge1xuICBib3gtc2hhZG93OiAwcHggMi42cHggNS44cHggLTIuMzFweCByZ2JhKDAsIDAsIDAsIDAuMTQpLCAwcHggOHB4IDEycHggMS4wNXB4IHJnYmEoMCwgMCwgMCwgMC4wNDYpLCAwcHggNC40cHggMTZweCAyLjJweCByZ2JhKDAsIDAsIDAsIDAuMDYpO1xufVxuXG4uZWxldmF0aW9uLTcge1xuICBib3gtc2hhZG93OiAwcHggMy41cHggNi44NXB4IC0zLjNweCByZ2JhKDAsIDAsIDAsIDAuMTQpLCAwcHggMTFweCAxNi41cHggMS41cHggcmdiYSgwLCAwLCAwLCAwLjA1MiksIDBweCA1LjNweCAyMnB4IDMuNHB4IHJnYmEoMCwgMCwgMCwgMC4wNik7XG59XG5cbi5lbGV2YXRpb24tOCB7XG4gIGJveC1zaGFkb3c6IDBweCA0LjdweCA4LjI1cHggLTQuNjJweCByZ2JhKDAsIDAsIDAsIDAuMTQpLCAwcHggMTVweCAyMi41cHggMi4xcHggcmdiYSgwLCAwLCAwLCAwLjA2KSwgMHB4IDYuNXB4IDMwcHggNXB4IHJnYmEoMCwgMCwgMCwgMC4wNik7XG59XG5cbi5lbGV2YXRpb24tOSB7XG4gIGJveC1zaGFkb3c6IDBweCA3LjRweCAxMS40cHggLTcuNTlweCByZ2JhKDAsIDAsIDAsIDAuMTQpLCAwcHggMjRweCAzNnB4IDMuNDVweCByZ2JhKDAsIDAsIDAsIDAuMDc4KSwgMHB4IDkuMnB4IDQ4cHggOC42cHggcmdiYSgwLCAwLCAwLCAwLjA2KTtcbn1cblxuLmFsaWduLWJhc2VsaW5lIHtcbiAgYWxpZ24taXRlbXM6IGJhc2VsaW5lO1xufVxuXG4uYWxpZ24tY2VudGVyIHtcbiAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbn1cblxuLmFsaWduLWVuZCB7XG4gIGFsaWduLWl0ZW1zOiBmbGV4LWVuZDtcbn1cblxuLmFsaWduLXNwYWNlLWFyb3VuZCB7XG4gIGFsaWduLWl0ZW1zOiBzcGFjZS1hcm91bmQ7XG59XG5cbi5hbGlnbi1zcGFjZS1iZXR3ZWVuIHtcbiAgYWxpZ24taXRlbXM6IHNwYWNlLWJldHdlZW47XG59XG5cbi5hbGlnbi1zdGFydCB7XG4gIGFsaWduLWl0ZW1zOiBmbGV4LXN0YXJ0O1xufVxuXG4uYWxpZ24tc3RyZXRjaCB7XG4gIGFsaWduLWl0ZW1zOiBzdHJldGNoO1xufVxuXG4uYWxpZ24tY29udGVudC1iYXNlbGluZSB7XG4gIGFsaWduLWNvbnRlbnQ6IGJhc2VsaW5lO1xufVxuXG4uYWxpZ24tY29udGVudC1jZW50ZXIge1xuICBhbGlnbi1jb250ZW50OiBjZW50ZXI7XG59XG5cbi5hbGlnbi1jb250ZW50LWVuZCB7XG4gIGFsaWduLWNvbnRlbnQ6IGZsZXgtZW5kO1xufVxuXG4uYWxpZ24tY29udGVudC1zcGFjZS1hcm91bmQge1xuICBhbGlnbi1jb250ZW50OiBzcGFjZS1hcm91bmQ7XG59XG5cbi5hbGlnbi1jb250ZW50LXNwYWNlLWJldHdlZW4ge1xuICBhbGlnbi1jb250ZW50OiBzcGFjZS1iZXR3ZWVuO1xufVxuXG4uYWxpZ24tY29udGVudC1zdGFydCB7XG4gIGFsaWduLWNvbnRlbnQ6IGZsZXgtc3RhcnQ7XG59XG5cbi5hbGlnbi1jb250ZW50LXN0cmV0Y2gge1xuICBhbGlnbi1jb250ZW50OiBzdHJldGNoO1xufVxuXG4uanVzdGlmeS1iYXNlbGluZSB7XG4gIGp1c3RpZnktY29udGVudDogYmFzZWxpbmU7XG59XG5cbi5qdXN0aWZ5LWNlbnRlciB7XG4gIGp1c3RpZnktY29udGVudDogY2VudGVyO1xufVxuXG4uanVzdGlmeS1lbmQge1xuICBqdXN0aWZ5LWNvbnRlbnQ6IGZsZXgtZW5kO1xufVxuXG4uanVzdGlmeS1zcGFjZS1hcm91bmQge1xuICBqdXN0aWZ5LWNvbnRlbnQ6IHNwYWNlLWFyb3VuZDtcbn1cblxuLmp1c3RpZnktc3BhY2UtYmV0d2VlbiB7XG4gIGp1c3RpZnktY29udGVudDogc3BhY2UtYmV0d2Vlbjtcbn1cblxuLmp1c3RpZnktc3RhcnQge1xuICBqdXN0aWZ5LWNvbnRlbnQ6IGZsZXgtc3RhcnQ7XG59XG5cbi5qdXN0aWZ5LXN0cmV0Y2gge1xuICBqdXN0aWZ5LWNvbnRlbnQ6IHN0cmV0Y2g7XG59XG5cbi5mbGV4LWNvbHVtbiB7XG4gIGZsZXgtZGlyZWN0aW9uOiBjb2x1bW47XG59XG5cbi5mbGV4LWNvbHVtbi1yZXZlcnNlIHtcbiAgZmxleC1kaXJlY3Rpb246IGNvbHVtbi1yZXZlcnNlO1xufVxuXG4uZmxleC1yb3cge1xuICBmbGV4LWRpcmVjdGlvbjogcm93O1xufVxuXG4uZmxleC1yb3ctcmV2ZXJzZSB7XG4gIGZsZXgtZGlyZWN0aW9uOiByb3ctcmV2ZXJzZTtcbn1cblxuLmZsZXgtd3JhcCB7XG4gIGZsZXgtd3JhcDogd3JhcDtcbn1cblxuLmZsZXgtbm93cmFwIHtcbiAgZmxleC13cmFwOiBub3dyYXA7XG59XG5cbi5mbGV4IHtcbiAgZGlzcGxheTogZmxleDtcbn1cblxuaHRtbCAuY29udGVudCAjbWFpbi1jb250ZW50LmxheW91dC1jb250ZW50IHtcbiAgbWFyZ2luOiAwO1xuICBtYXgtd2lkdGg6IG5vbmU7XG59XG5cbi5sYXlvdXQtY29udGVudCAuY29udGFpbmVyIHtcbiAgbWF4LXdpZHRoOiAxMzY2cHg7XG59XG4ubGF5b3V0LWNvbnRlbnQgLmNvbnRhaW5lci5zaWRlYmFyLWxheW91dHMtc2VjdGlvbl9fbGF5b3V0LXByZXZpZXcge1xuICBwYWRkaW5nOiAwO1xufVxuLmxheW91dC1jb250ZW50IC5jb250YWluZXIuc2lkZWJhci1sYXlvdXRzLXNlY3Rpb25fX2xheW91dC1wcmV2aWV3IC5zaWRlYmFyLWxheW91dHMtc2VjdGlvbl9fbGF5b3V0LXByZXZpZXdfX3JvdyB7XG4gIG1hcmdpbjogMDtcbn1cbkBtZWRpYSAobWF4LXdpZHRoOiA1OTlweCkge1xuICAubGF5b3V0LWNvbnRlbnQgLmNvbnRhaW5lciB7XG4gICAgcGFkZGluZy1sZWZ0OiAxLjVyZW0gIWltcG9ydGFudDtcbiAgICBwYWRkaW5nLXJpZ2h0OiAxLjVyZW0gIWltcG9ydGFudDtcbiAgfVxuICAubGF5b3V0LWNvbnRlbnQgZGl2W2NsYXNzKj1jb2wtbWRdIHtcbiAgICBwYWRkaW5nLWxlZnQ6IDAuNXJlbTtcbiAgICBwYWRkaW5nLXJpZ2h0OiAwLjVyZW07XG4gIH1cbiAgLmxheW91dC1jb250ZW50IC5yb3cge1xuICAgIG1hcmdpbi1sZWZ0OiAtMC41cmVtO1xuICAgIG1hcmdpbi1yaWdodDogLTAuNXJlbTtcbiAgfVxufVxuQG1lZGlhIChtaW4td2lkdGg6IDYwMHB4KSB7XG4gIC5sYXlvdXQtY29udGVudCAuY29udGFpbmVyIHtcbiAgICBwYWRkaW5nLWxlZnQ6IDEuNXJlbSAhaW1wb3J0YW50O1xuICAgIHBhZGRpbmctcmlnaHQ6IDEuNXJlbSAhaW1wb3J0YW50O1xuICB9XG4gIC5sYXlvdXQtY29udGVudCBkaXZbY2xhc3MqPWNvbC1tZF0ge1xuICAgIHBhZGRpbmctbGVmdDogMC43NXJlbTtcbiAgICBwYWRkaW5nLXJpZ2h0OiAwLjc1cmVtO1xuICB9XG4gIC5sYXlvdXQtY29udGVudCAucm93IHtcbiAgICBtYXJnaW4tbGVmdDogLTAuNzVyZW07XG4gICAgbWFyZ2luLXJpZ2h0OiAtMC43NXJlbTtcbiAgfVxufVxuQG1lZGlhIChtaW4td2lkdGg6IDkwMHB4KSB7XG4gIC5sYXlvdXQtY29udGVudCAuY29udGFpbmVyIHtcbiAgICBwYWRkaW5nLWxlZnQ6IDRyZW0gIWltcG9ydGFudDtcbiAgICBwYWRkaW5nLXJpZ2h0OiA0cmVtICFpbXBvcnRhbnQ7XG4gIH1cbiAgLmxheW91dC1jb250ZW50IGRpdltjbGFzcyo9Y29sLW1kXSB7XG4gICAgcGFkZGluZy1sZWZ0OiAxcmVtO1xuICAgIHBhZGRpbmctcmlnaHQ6IDFyZW07XG4gIH1cbiAgLmxheW91dC1jb250ZW50IC5yb3cge1xuICAgIG1hcmdpbi1sZWZ0OiAtMXJlbTtcbiAgICBtYXJnaW4tcmlnaHQ6IC0xcmVtO1xuICB9XG59XG5cbi5tYXgtd2lkdGgtbm9uZSB7XG4gIG1heC13aWR0aDogXCJub25lXCI7XG59XG5cbi5tYXgtd2lkdGgteHNtYWxsIHtcbiAgbWF4LXdpZHRoOiAzMjBweDtcbn1cblxuLm1heC13aWR0aC1mb3JtLXNtYWxsIHtcbiAgbWF4LXdpZHRoOiA0MDBweDtcbn1cblxuLm1heC13aWR0aC1mb3JtIHtcbiAgbWF4LXdpZHRoOiA1MDBweDtcbn1cblxuLm1heC13aWR0aC1zbWFsbCB7XG4gIG1heC13aWR0aDogNTIwcHg7XG59XG5cbi5tYXgtd2lkdGgtbWVkaXVtIHtcbiAgbWF4LXdpZHRoOiA3MjBweDtcbn1cblxuLm1heC13aWR0aC1sYXJnZSB7XG4gIG1heC13aWR0aDogOTAwcHg7XG59XG5cbi5tYXgtd2lkdGgteGxhcmdlIHtcbiAgbWF4LXdpZHRoOiAxMjAwcHg7XG59XG5cbi5tYXgtd2lkdGgtZnVsbCB7XG4gIG1heC13aWR0aDogMTM2NnB4O1xufVxuXG4uYm9yZGVyLXJhZGl1cy1ub25lIHtcbiAgYm9yZGVyLXJhZGl1czogMDtcbn1cblxuLmJvcmRlci1yYWRpdXMtc21hbGwge1xuICBib3JkZXItcmFkaXVzOiAycHg7XG59XG5cbi5ib3JkZXItcmFkaXVzLW1lZGl1bSB7XG4gIGJvcmRlci1yYWRpdXM6IDRweDtcbn1cblxuLmJvcmRlci1yYWRpdXMtbGFyZ2Uge1xuICBib3JkZXItcmFkaXVzOiA2cHg7XG59XG5cbi5ib3JkZXItcmFkaXVzLXhsYXJnZSB7XG4gIGJvcmRlci1yYWRpdXM6IDhweDtcbn1cblxuLmZvbnQtZmFtaWx5LW1vbm8ge1xuICBmb250LWZhbWlseTogXCJTb3VyY2UgQ29kZSBQcm9cIiwgTWVubG8sIG1vbm9zcGFjZTtcbn1cbi5mb250LWZhbWlseS1zYW5zIHtcbiAgZm9udC1mYW1pbHk6IFwiU291cmNlIFNhbnMgUHJvXCIsIFRhaG9tYSwgXCJUcmVidWNoZXQgTVNcIiwgc2Fucy1zZXJpZjtcbn1cbi5mb250LWZhbWlseS1zZXJpZiB7XG4gIGZvbnQtZmFtaWx5OiBcIlNvdXJjZSBTZXJpZiBQcm9cIiwgR2VvcmdpYSwgQ2FtYnJpYSwgXCJUaW1lcyBOZXcgUm9tYW5cIiwgVGltZXMsIHNlcmlmO1xufVxuXG4uZm9udC13ZWlnaHQtYm9sZCB7XG4gIGZvbnQtd2VpZ2h0OiA3MDA7XG59XG4uZm9udC13ZWlnaHQtZXh0cmEtbGlnaHQge1xuICBmb250LXdlaWdodDogMjAwO1xufVxuLmZvbnQtd2VpZ2h0LWxpZ2h0IHtcbiAgZm9udC13ZWlnaHQ6IDMwMDtcbn1cbi5mb250LXdlaWdodC1ub3JtYWwge1xuICBmb250LXdlaWdodDogNDAwO1xufVxuLmZvbnQtd2VpZ2h0LXNlbWktYm9sZCB7XG4gIGZvbnQtd2VpZ2h0OiA2MDA7XG59XG5cbi5jb250ZW50IC5sYXlvdXQtY29udGVudCBoMSwgLmZvbnQtc2l6ZS1oZWFkaW5nLWYxIHtcbiAgZm9udC13ZWlnaHQ6IDYwMDtcbn1cbkBtZWRpYSAobWF4LXdpZHRoOiA1OTlweCkge1xuICAuY29udGVudCAubGF5b3V0LWNvbnRlbnQgaDEsIC5mb250LXNpemUtaGVhZGluZy1mMSB7XG4gICAgZm9udC1zaXplOiAycmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjEyNTtcbiAgfVxufVxuQG1lZGlhIChtaW4td2lkdGg6IDYwMHB4KSB7XG4gIC5jb250ZW50IC5sYXlvdXQtY29udGVudCBoMSwgLmZvbnQtc2l6ZS1oZWFkaW5nLWYxIHtcbiAgICBmb250LXNpemU6IDIuNjI1cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjE0MztcbiAgfVxufVxuQG1lZGlhIChtaW4td2lkdGg6IDkwMHB4KSB7XG4gIC5jb250ZW50IC5sYXlvdXQtY29udGVudCBoMSwgLmZvbnQtc2l6ZS1oZWFkaW5nLWYxIHtcbiAgICBmb250LXNpemU6IDNyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMTY3O1xuICB9XG59XG5AbWVkaWEgKG1pbi13aWR0aDogMTIwMHB4KSB7XG4gIC5jb250ZW50IC5sYXlvdXQtY29udGVudCBoMSwgLmZvbnQtc2l6ZS1oZWFkaW5nLWYxIHtcbiAgICBmb250LXNpemU6IDMuNDM4cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjAxODtcbiAgfVxufVxuXG4uY29udGVudCAubGF5b3V0LWNvbnRlbnQgaDIsIC5mb250LXNpemUtaGVhZGluZy1mMiB7XG4gIGZvbnQtd2VpZ2h0OiA2MDA7XG59XG5AbWVkaWEgKG1heC13aWR0aDogNTk5cHgpIHtcbiAgLmNvbnRlbnQgLmxheW91dC1jb250ZW50IGgyLCAuZm9udC1zaXplLWhlYWRpbmctZjIge1xuICAgIGZvbnQtc2l6ZTogMS44MTNyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMTAzO1xuICB9XG59XG5AbWVkaWEgKG1pbi13aWR0aDogNjAwcHgpIHtcbiAgLmNvbnRlbnQgLmxheW91dC1jb250ZW50IGgyLCAuZm9udC1zaXplLWhlYWRpbmctZjIge1xuICAgIGZvbnQtc2l6ZTogMi4xODhyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMDI5O1xuICB9XG59XG5AbWVkaWEgKG1pbi13aWR0aDogOTAwcHgpIHtcbiAgLmNvbnRlbnQgLmxheW91dC1jb250ZW50IGgyLCAuZm9udC1zaXplLWhlYWRpbmctZjIge1xuICAgIGZvbnQtc2l6ZTogMi40MzhyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMDI2O1xuICB9XG59XG5AbWVkaWEgKG1pbi13aWR0aDogMTIwMHB4KSB7XG4gIC5jb250ZW50IC5sYXlvdXQtY29udGVudCBoMiwgLmZvbnQtc2l6ZS1oZWFkaW5nLWYyIHtcbiAgICBmb250LXNpemU6IDIuNzVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMDkxO1xuICB9XG59XG5cbi5jb250ZW50IC5sYXlvdXQtY29udGVudCBoMywgLmZvbnQtc2l6ZS1oZWFkaW5nLWYzIHtcbiAgZm9udC13ZWlnaHQ6IDYwMDtcbn1cbkBtZWRpYSAobWF4LXdpZHRoOiA1OTlweCkge1xuICAuY29udGVudCAubGF5b3V0LWNvbnRlbnQgaDMsIC5mb250LXNpemUtaGVhZGluZy1mMyB7XG4gICAgZm9udC1zaXplOiAxLjYyNXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4yMztcbiAgfVxufVxuQG1lZGlhIChtaW4td2lkdGg6IDYwMHB4KSB7XG4gIC5jb250ZW50IC5sYXlvdXQtY29udGVudCBoMywgLmZvbnQtc2l6ZS1oZWFkaW5nLWYzIHtcbiAgICBmb250LXNpemU6IDEuODc1cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjI7XG4gIH1cbn1cbkBtZWRpYSAobWluLXdpZHRoOiA5MDBweCkge1xuICAuY29udGVudCAubGF5b3V0LWNvbnRlbnQgaDMsIC5mb250LXNpemUtaGVhZGluZy1mMyB7XG4gICAgZm9udC1zaXplOiAycmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjEyNTtcbiAgfVxufVxuQG1lZGlhIChtaW4td2lkdGg6IDEyMDBweCkge1xuICAuY29udGVudCAubGF5b3V0LWNvbnRlbnQgaDMsIC5mb250LXNpemUtaGVhZGluZy1mMyB7XG4gICAgZm9udC1zaXplOiAyLjE4OHJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4xNDM7XG4gIH1cbn1cblxuLmNvbnRlbnQgLmxheW91dC1jb250ZW50IGg0LCAuZm9udC1zaXplLWhlYWRpbmctZjQge1xuICBmb250LXdlaWdodDogNjAwO1xufVxuQG1lZGlhIChtYXgtd2lkdGg6IDU5OXB4KSB7XG4gIC5jb250ZW50IC5sYXlvdXQtY29udGVudCBoNCwgLmZvbnQtc2l6ZS1oZWFkaW5nLWY0IHtcbiAgICBmb250LXNpemU6IDEuMzc1cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjI0NDtcbiAgfVxufVxuQG1lZGlhIChtaW4td2lkdGg6IDYwMHB4KSB7XG4gIC5jb250ZW50IC5sYXlvdXQtY29udGVudCBoNCwgLmZvbnQtc2l6ZS1oZWFkaW5nLWY0IHtcbiAgICBmb250LXNpemU6IDEuNTYzcmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjI4O1xuICB9XG59XG5AbWVkaWEgKG1pbi13aWR0aDogOTAwcHgpIHtcbiAgLmNvbnRlbnQgLmxheW91dC1jb250ZW50IGg0LCAuZm9udC1zaXplLWhlYWRpbmctZjQge1xuICAgIGZvbnQtc2l6ZTogMS42MjVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMjMwNzY5MjMxO1xuICB9XG59XG5AbWVkaWEgKG1pbi13aWR0aDogMTIwMHB4KSB7XG4gIC5jb250ZW50IC5sYXlvdXQtY29udGVudCBoNCwgLmZvbnQtc2l6ZS1oZWFkaW5nLWY0IHtcbiAgICBmb250LXNpemU6IDEuNzVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMTQzO1xuICB9XG59XG5cbi5jb250ZW50IC5sYXlvdXQtY29udGVudCBoNSwgLmZvbnQtc2l6ZS1oZWFkaW5nLWY1IHtcbiAgZm9udC13ZWlnaHQ6IDYwMDtcbn1cbkBtZWRpYSAobWF4LXdpZHRoOiA1OTlweCkge1xuICAuY29udGVudCAubGF5b3V0LWNvbnRlbnQgaDUsIC5mb250LXNpemUtaGVhZGluZy1mNSB7XG4gICAgZm9udC1zaXplOiAxLjI1cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjI7XG4gIH1cbn1cbkBtZWRpYSAobWluLXdpZHRoOiA2MDBweCkge1xuICAuY29udGVudCAubGF5b3V0LWNvbnRlbnQgaDUsIC5mb250LXNpemUtaGVhZGluZy1mNSB7XG4gICAgZm9udC1zaXplOiAxLjMxM3JlbTtcbiAgICBsaW5lLWhlaWdodDogMS4xNDM7XG4gIH1cbn1cbkBtZWRpYSAobWluLXdpZHRoOiA5MDBweCkge1xuICAuY29udGVudCAubGF5b3V0LWNvbnRlbnQgaDUsIC5mb250LXNpemUtaGVhZGluZy1mNSB7XG4gICAgZm9udC1zaXplOiAxLjM3NXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4yNzM7XG4gIH1cbn1cbkBtZWRpYSAobWluLXdpZHRoOiAxMjAwcHgpIHtcbiAgLmNvbnRlbnQgLmxheW91dC1jb250ZW50IGg1LCAuZm9udC1zaXplLWhlYWRpbmctZjUge1xuICAgIGZvbnQtc2l6ZTogMS4zNzVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMjQ0O1xuICB9XG59XG5cbi5jb250ZW50IC5sYXlvdXQtY29udGVudCAuZm9udC1zaXplLWRpc3BsYXktbGFyZ2UsIC5mb250LXNpemUtZGlzcGxheS1sYXJnZSB7XG4gIGZvbnQtd2VpZ2h0OiA3MDA7XG59XG5AbWVkaWEgKG1heC13aWR0aDogNTk5cHgpIHtcbiAgLmNvbnRlbnQgLmxheW91dC1jb250ZW50IC5mb250LXNpemUtZGlzcGxheS1sYXJnZSwgLmZvbnQtc2l6ZS1kaXNwbGF5LWxhcmdlIHtcbiAgICBmb250LXNpemU6IDIuODc1cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAwLjk1NztcbiAgfVxufVxuQG1lZGlhIChtaW4td2lkdGg6IDYwMHB4KSB7XG4gIC5jb250ZW50IC5sYXlvdXQtY29udGVudCAuZm9udC1zaXplLWRpc3BsYXktbGFyZ2UsIC5mb250LXNpemUtZGlzcGxheS1sYXJnZSB7XG4gICAgZm9udC1zaXplOiA0LjQzOHJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4wMTtcbiAgfVxufVxuQG1lZGlhIChtaW4td2lkdGg6IDkwMHB4KSB7XG4gIC5jb250ZW50IC5sYXlvdXQtY29udGVudCAuZm9udC1zaXplLWRpc3BsYXktbGFyZ2UsIC5mb250LXNpemUtZGlzcGxheS1sYXJnZSB7XG4gICAgZm9udC1zaXplOiA1LjU2M3JlbTtcbiAgICBsaW5lLWhlaWdodDogMC45ODk7XG4gIH1cbn1cbkBtZWRpYSAobWluLXdpZHRoOiAxMjAwcHgpIHtcbiAgLmNvbnRlbnQgLmxheW91dC1jb250ZW50IC5mb250LXNpemUtZGlzcGxheS1sYXJnZSwgLmZvbnQtc2l6ZS1kaXNwbGF5LWxhcmdlIHtcbiAgICBmb250LXNpemU6IDYuNjg4cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAwLjk3MjtcbiAgfVxufVxuXG4uY29udGVudCAubGF5b3V0LWNvbnRlbnQgLmZvbnQtc2l6ZS1kaXNwbGF5LXNtYWxsLCAuZm9udC1zaXplLWRpc3BsYXktc21hbGwge1xuICBmb250LXdlaWdodDogNzAwO1xufVxuQG1lZGlhIChtYXgtd2lkdGg6IDU5OXB4KSB7XG4gIC5jb250ZW50IC5sYXlvdXQtY29udGVudCAuZm9udC1zaXplLWRpc3BsYXktc21hbGwsIC5mb250LXNpemUtZGlzcGxheS1zbWFsbCB7XG4gICAgZm9udC1zaXplOiAyLjU2M3JlbTtcbiAgICBsaW5lLWhlaWdodDogMC45NzY7XG4gIH1cbn1cbkBtZWRpYSAobWluLXdpZHRoOiA2MDBweCkge1xuICAuY29udGVudCAubGF5b3V0LWNvbnRlbnQgLmZvbnQtc2l6ZS1kaXNwbGF5LXNtYWxsLCAuZm9udC1zaXplLWRpc3BsYXktc21hbGwge1xuICAgIGZvbnQtc2l6ZTogMi45MzhyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMDIxO1xuICB9XG59XG5AbWVkaWEgKG1pbi13aWR0aDogOTAwcHgpIHtcbiAgLmNvbnRlbnQgLmxheW91dC1jb250ZW50IC5mb250LXNpemUtZGlzcGxheS1zbWFsbCwgLmZvbnQtc2l6ZS1kaXNwbGF5LXNtYWxsIHtcbiAgICBmb250LXNpemU6IDQuNXJlbTtcbiAgICBsaW5lLWhlaWdodDogMTtcbiAgfVxufVxuQG1lZGlhIChtaW4td2lkdGg6IDEyMDBweCkge1xuICAuY29udGVudCAubGF5b3V0LWNvbnRlbnQgLmZvbnQtc2l6ZS1kaXNwbGF5LXNtYWxsLCAuZm9udC1zaXplLWRpc3BsYXktc21hbGwge1xuICAgIGZvbnQtc2l6ZTogNS4zNzVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMDIzO1xuICB9XG59XG5cbi5mb250LXNpemUtbG9uZy1mb3JtLXNhbnMtc2VyaWYge1xuICBmb250LXNpemU6IDEuMDYzcmVtO1xuICBsaW5lLWhlaWdodDogMS42NDc7XG59XG5AbWVkaWEgKG1pbi13aWR0aDogOTAwcHgpIHtcbiAgLmZvbnQtc2l6ZS1sb25nLWZvcm0tc2Fucy1zZXJpZiB7XG4gICAgZm9udC1zaXplOiAxLjI1cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjU7XG4gIH1cbn1cblxuLmZvbnQtc2l6ZS1sb25nLWZvcm0tc2VyaWYge1xuICBmb250LXNpemU6IDEuMDYzcmVtO1xuICBsaW5lLWhlaWdodDogMS42NDc7XG4gIGZvbnQtZmFtaWx5OiBcIlNvdXJjZSBTZXJpZiBQcm9cIiwgR2VvcmdpYSwgQ2FtYnJpYSwgXCJUaW1lcyBOZXcgUm9tYW5cIiwgVGltZXMsIHNlcmlmO1xufVxuQG1lZGlhIChtaW4td2lkdGg6IDkwMHB4KSB7XG4gIC5mb250LXNpemUtbG9uZy1mb3JtLXNlcmlmIHtcbiAgICBmb250LXNpemU6IDEuMjVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgfVxufVxuXG5AbWVkaWEgKG1heC13aWR0aDogNTk5cHgpIHtcbiAgLmZvbnQtc2l6ZS1wYXJhZ3JhcGgtbGFyZ2Uge1xuICAgIGZvbnQtc2l6ZTogMS4yNXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4zNzk7XG4gIH1cbn1cbkBtZWRpYSAobWluLXdpZHRoOiA2MDBweCkge1xuICAuZm9udC1zaXplLXBhcmFncmFwaC1sYXJnZSB7XG4gICAgZm9udC1zaXplOiAxLjQzOHJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4zNjI7XG4gIH1cbn1cbkBtZWRpYSAobWluLXdpZHRoOiA5MDBweCkge1xuICAuZm9udC1zaXplLXBhcmFncmFwaC1sYXJnZSB7XG4gICAgZm9udC1zaXplOiAxLjU2M3JlbTtcbiAgICBsaW5lLWhlaWdodDogMS40MTI7XG4gIH1cbn1cbkBtZWRpYSAobWluLXdpZHRoOiAxMjAwcHgpIHtcbiAgLmZvbnQtc2l6ZS1wYXJhZ3JhcGgtbGFyZ2Uge1xuICAgIGZvbnQtc2l6ZTogMS43NXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4yODY7XG4gIH1cbn1cblxuLmNvbnRlbnQgLmxheW91dC1jb250ZW50IHAsIC5mb250LXNpemUtcGFyYWdyYXBoLWJhc2Uge1xuICBmb250LXNpemU6IDEuMTI1cmVtO1xuICBsaW5lLWhlaWdodDogMS41NTY7XG59XG5cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi10ZXh0LCAuZm9udC1zaXplLXBhcmFncmFwaC1iYXNlLXNlbWktYm9sZCB7XG4gIGZvbnQtc2l6ZTogMS4xMjVyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjU1NjtcbiAgZm9udC13ZWlnaHQ6IDYwMDtcbn1cblxuLmZvbnQtc2l6ZS1wYXJhZ3JhcGgtc21hbGwge1xuICBmb250LXNpemU6IDFyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjU7XG59XG5cbi5mb250LXNpemUtcGFyYWdyYXBoLXhzbWFsbCB7XG4gIGZvbnQtc2l6ZTogMC45ZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjM4OTtcbn1cblxuLmZvbnQtc2l6ZS1wYXJhZ3JhcGgtdGlueSB7XG4gIGZvbnQtc2l6ZTogMC42ODhyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjM5MTtcbn1cblxuLmZvbnQtc2l6ZS1zbWFsbC1jYXBzIHtcbiAgZm9udC1zaXplOiAwLjlyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjM4OTtcbiAgZm9udC13ZWlnaHQ6IDYwMDtcbiAgbGV0dGVyLXNwYWNpbmc6IDFweDtcbiAgdGV4dC10cmFuc2Zvcm06IHVwcGVyY2FzZTtcbn1cblxuYm9keSAuY29udGVudCBoNSxcbmJvZHkgLmNvbnRlbnQgLmZvbnQtc3BlYy01LCBib2R5IC5jb250ZW50IGg0LFxuYm9keSAuY29udGVudCAuZm9udC1zcGVjLTQsIGJvZHkgLmNvbnRlbnQgaDMsXG5ib2R5IC5jb250ZW50IC5mb250LXNwZWMtMywgYm9keSAuY29udGVudCBoMixcbmJvZHkgLmNvbnRlbnQgLmZvbnQtc3BlYy0yLCBib2R5IC5jb250ZW50IGgxLFxuYm9keSAuY29udGVudCAuZm9udC1zcGVjLTEge1xuICBmb250LXdlaWdodDogNjAwO1xuICBsaW5lLWhlaWdodDogMS4yNTtcbn1cblxuYm9keSAuY29udGVudCAuc21hbGwtY2FwcywgYm9keSAuY29udGVudCBwLnN1cGVyZmluZS1wcmludCwgYm9keSAuY29udGVudCBwLmxhcmdlLCBib2R5IC5jb250ZW50IGg1LFxuYm9keSAuY29udGVudCAuZm9udC1zcGVjLTUsIGJvZHkgLmNvbnRlbnQgaDQsXG5ib2R5IC5jb250ZW50IC5mb250LXNwZWMtNCwgYm9keSAuY29udGVudCBoMyxcbmJvZHkgLmNvbnRlbnQgLmZvbnQtc3BlYy0zLCBib2R5IC5jb250ZW50IGgyLFxuYm9keSAuY29udGVudCAuZm9udC1zcGVjLTIsIGJvZHkgLmNvbnRlbnQgaDEsXG5ib2R5IC5jb250ZW50IC5mb250LXNwZWMtMSwgYm9keSAuY29udGVudCBwLmZpbmUtcHJpbnQge1xuICBtYXJnaW46IDAgMCAxNnB4O1xufVxuXG5ib2R5IC5jb250ZW50IHAuZmluZS1wcmludCB7XG4gIGZvbnQtc2l6ZTogMWVtO1xufVxuXG5ib2R5IC5jb250ZW50IGgxLFxuYm9keSAuY29udGVudCAuZm9udC1zcGVjLTEge1xuICBmb250LXNpemU6IDNlbTtcbiAgbGluZS1oZWlnaHQ6IDEuMDU7XG59XG5AbWVkaWEgKG1pbi13aWR0aDogNzY4cHgpIGFuZCAobWF4LXdpZHRoOiA5NzlweCkge1xuICBib2R5IC5jb250ZW50IGgxLFxuICBib2R5IC5jb250ZW50IC5mb250LXNwZWMtMSB7XG4gICAgZm9udC1zaXplOiAyLjVlbTtcbiAgfVxufVxuQG1lZGlhIChtYXgtd2lkdGg6IDc2N3B4KSB7XG4gIGJvZHkgLmNvbnRlbnQgaDEsXG4gIGJvZHkgLmNvbnRlbnQgLmZvbnQtc3BlYy0xIHtcbiAgICBmb250LXNpemU6IDJlbTtcbiAgfVxufVxuXG5ib2R5IC5jb250ZW50IGgyLFxuYm9keSAuY29udGVudCAuZm9udC1zcGVjLTIge1xuICBmb250LXNpemU6IDIuMjVlbTtcbn1cbkBtZWRpYSAobWluLXdpZHRoOiA3NjhweCkgYW5kIChtYXgtd2lkdGg6IDk3OXB4KSB7XG4gIGJvZHkgLmNvbnRlbnQgaDIsXG4gIGJvZHkgLmNvbnRlbnQgLmZvbnQtc3BlYy0yIHtcbiAgICBmb250LXNpemU6IDJlbTtcbiAgfVxufVxuQG1lZGlhIChtYXgtd2lkdGg6IDc2N3B4KSB7XG4gIGJvZHkgLmNvbnRlbnQgaDIsXG4gIGJvZHkgLmNvbnRlbnQgLmZvbnQtc3BlYy0yIHtcbiAgICBmb250LXNpemU6IDEuNjI1ZW07XG4gIH1cbn1cblxuYm9keSAuY29udGVudCBoMyxcbmJvZHkgLmNvbnRlbnQgLmZvbnQtc3BlYy0zIHtcbiAgZm9udC1zaXplOiAxLjc1ZW07XG59XG5AbWVkaWEgKG1pbi13aWR0aDogNzY4cHgpIGFuZCAobWF4LXdpZHRoOiA5NzlweCkge1xuICBib2R5IC5jb250ZW50IGgzLFxuICBib2R5IC5jb250ZW50IC5mb250LXNwZWMtMyB7XG4gICAgZm9udC1zaXplOiAxLjVlbTtcbiAgfVxufVxuQG1lZGlhIChtYXgtd2lkdGg6IDc2N3B4KSB7XG4gIGJvZHkgLmNvbnRlbnQgaDMsXG4gIGJvZHkgLmNvbnRlbnQgLmZvbnQtc3BlYy0zIHtcbiAgICBmb250LXNpemU6IDEuMzc1ZW07XG4gIH1cbn1cblxuYm9keSAuY29udGVudCBoNCxcbmJvZHkgLmNvbnRlbnQgLmZvbnQtc3BlYy00IHtcbiAgZm9udC1zaXplOiAxLjEyNWVtO1xufVxuXG5ib2R5IC5jb250ZW50IGg1LFxuYm9keSAuY29udGVudCAuZm9udC1zcGVjLTUge1xuICBmb250LXNpemU6IDFlbTtcbn1cblxuYm9keSAuY29udGVudCBwLmxhcmdlIHtcbiAgZm9udC1zaXplOiAxLjc1ZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjI1ZW07XG59XG5AbWVkaWEgKG1pbi13aWR0aDogNzY4cHgpIGFuZCAobWF4LXdpZHRoOiA5NzlweCkge1xuICBib2R5IC5jb250ZW50IHAubGFyZ2Uge1xuICAgIGZvbnQtc2l6ZTogMS41ZW07XG4gIH1cbn1cbkBtZWRpYSAobWF4LXdpZHRoOiA3NjdweCkge1xuICBib2R5IC5jb250ZW50IHAubGFyZ2Uge1xuICAgIGZvbnQtc2l6ZTogMS4zNzVlbTtcbiAgfVxufVxuXG5ib2R5IC5jb250ZW50IHAuc3VwZXJmaW5lLXByaW50IHtcbiAgZm9udC1zaXplOiAwLjg1NzE0ZW07XG59XG5cbmJvZHkgLmNvbnRlbnQgLnNtYWxsLWNhcHMge1xuICBmb250LXNpemU6IDAuODMzMTI1ZW07XG4gIGZvbnQtd2VpZ2h0OiA0MDA7XG4gIGxldHRlci1zcGFjaW5nOiAxcHg7XG4gIHRleHQtdHJhbnNmb3JtOiB1cHBlcmNhc2U7XG59XG5cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJTb3VyY2UgQ29kZSBQcm9cIjtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogMjAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTIwMC5lb3RcIik7XG4gIHNyYzogbG9jYWwoXCJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTIwMC5lb3Q/I2llZml4XCIpIGZvcm1hdChcImVtYmVkZGVkLW9wZW50eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL3NvdXJjZS1jb2RlLXByby12MjEtdmlldG5hbWVzZV9sYXRpbl9jeXJpbGxpYy0yMDAud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTIwMC53b2ZmXCIpIGZvcm1hdChcIndvZmZcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTIwMC50dGZcIikgZm9ybWF0KFwidHJ1ZXR5cGVcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTIwMC5zdmcjU291cmNlX0NvZGVfUHJvXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJTb3VyY2UgQ29kZSBQcm9cIjtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogMzAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTMwMC5lb3RcIik7XG4gIHNyYzogbG9jYWwoXCJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTMwMC5lb3Q/I2llZml4XCIpIGZvcm1hdChcImVtYmVkZGVkLW9wZW50eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL3NvdXJjZS1jb2RlLXByby12MjEtdmlldG5hbWVzZV9sYXRpbl9jeXJpbGxpYy0zMDAud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTMwMC53b2ZmXCIpIGZvcm1hdChcIndvZmZcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTMwMC50dGZcIikgZm9ybWF0KFwidHJ1ZXR5cGVcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTMwMC5zdmcjU291cmNlX0NvZGVfUHJvXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJTb3VyY2UgQ29kZSBQcm9cIjtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogNDAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTQwMC5lb3RcIik7XG4gIHNyYzogbG9jYWwoXCJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTQwMC5lb3Q/I2llZml4XCIpIGZvcm1hdChcImVtYmVkZGVkLW9wZW50eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL3NvdXJjZS1jb2RlLXByby12MjEtdmlldG5hbWVzZV9sYXRpbl9jeXJpbGxpYy00MDAud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTQwMC53b2ZmXCIpIGZvcm1hdChcIndvZmZcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTQwMC50dGZcIikgZm9ybWF0KFwidHJ1ZXR5cGVcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTQwMC5zdmcjU291cmNlX0NvZGVfUHJvXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJTb3VyY2UgQ29kZSBQcm9cIjtcbiAgZm9udC1zdHlsZTogaXRhbGljO1xuICBmb250LXdlaWdodDogNDAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLWl0YWxpYy5lb3RcIik7XG4gIHNyYzogbG9jYWwoXCJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLWl0YWxpYy5lb3Q/I2llZml4XCIpIGZvcm1hdChcImVtYmVkZGVkLW9wZW50eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL3NvdXJjZS1jb2RlLXByby12MjEtdmlldG5hbWVzZV9sYXRpbl9jeXJpbGxpYy1pdGFsaWMud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLWl0YWxpYy53b2ZmXCIpIGZvcm1hdChcIndvZmZcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLWl0YWxpYy50dGZcIikgZm9ybWF0KFwidHJ1ZXR5cGVcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLWl0YWxpYy5zdmcjU291cmNlX0NvZGVfUHJvXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJTb3VyY2UgQ29kZSBQcm9cIjtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogNjAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTYwMC5lb3RcIik7XG4gIHNyYzogbG9jYWwoXCJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTYwMC5lb3Q/I2llZml4XCIpIGZvcm1hdChcImVtYmVkZGVkLW9wZW50eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL3NvdXJjZS1jb2RlLXByby12MjEtdmlldG5hbWVzZV9sYXRpbl9jeXJpbGxpYy02MDAud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTYwMC53b2ZmXCIpIGZvcm1hdChcIndvZmZcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTYwMC50dGZcIikgZm9ybWF0KFwidHJ1ZXR5cGVcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTYwMC5zdmcjU291cmNlX0NvZGVfUHJvXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJTb3VyY2UgQ29kZSBQcm9cIjtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogNzAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTcwMC5lb3RcIik7XG4gIHNyYzogbG9jYWwoXCJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTcwMC5lb3Q/I2llZml4XCIpIGZvcm1hdChcImVtYmVkZGVkLW9wZW50eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL3NvdXJjZS1jb2RlLXByby12MjEtdmlldG5hbWVzZV9sYXRpbl9jeXJpbGxpYy03MDAud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTcwMC53b2ZmXCIpIGZvcm1hdChcIndvZmZcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTcwMC50dGZcIikgZm9ybWF0KFwidHJ1ZXR5cGVcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLWNvZGUtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTcwMC5zdmcjU291cmNlX0NvZGVfUHJvXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJTb3VyY2UgU2FucyBQcm9cIjtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogMjAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTIwMC5lb3RcIik7XG4gIHNyYzogbG9jYWwoXCJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTIwMC5lb3Q/I2llZml4XCIpIGZvcm1hdChcImVtYmVkZGVkLW9wZW50eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL3NvdXJjZS1zYW5zLXByby12MjEtdmlldG5hbWVzZV9sYXRpbl9jeXJpbGxpYy0yMDAud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTIwMC53b2ZmXCIpIGZvcm1hdChcIndvZmZcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTIwMC50dGZcIikgZm9ybWF0KFwidHJ1ZXR5cGVcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTIwMC5zdmcjU291cmNlX1NhbnNfUHJvXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJTb3VyY2UgU2FucyBQcm9cIjtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogMzAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTMwMC5lb3RcIik7XG4gIHNyYzogbG9jYWwoXCJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTMwMC5lb3Q/I2llZml4XCIpIGZvcm1hdChcImVtYmVkZGVkLW9wZW50eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL3NvdXJjZS1zYW5zLXByby12MjEtdmlldG5hbWVzZV9sYXRpbl9jeXJpbGxpYy0zMDAud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTMwMC53b2ZmXCIpIGZvcm1hdChcIndvZmZcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTMwMC50dGZcIikgZm9ybWF0KFwidHJ1ZXR5cGVcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTMwMC5zdmcjU291cmNlX1NhbnNfUHJvXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJTb3VyY2UgU2FucyBQcm9cIjtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogNDAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTQwMC5lb3RcIik7XG4gIHNyYzogbG9jYWwoXCJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTQwMC5lb3Q/I2llZml4XCIpIGZvcm1hdChcImVtYmVkZGVkLW9wZW50eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL3NvdXJjZS1zYW5zLXByby12MjEtdmlldG5hbWVzZV9sYXRpbl9jeXJpbGxpYy00MDAud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTQwMC53b2ZmXCIpIGZvcm1hdChcIndvZmZcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTQwMC50dGZcIikgZm9ybWF0KFwidHJ1ZXR5cGVcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTQwMC5zdmcjU291cmNlX1NhbnNfUHJvXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJTb3VyY2UgU2FucyBQcm9cIjtcbiAgZm9udC1zdHlsZTogaXRhbGljO1xuICBmb250LXdlaWdodDogNDAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLWl0YWxpYy5lb3RcIik7XG4gIHNyYzogbG9jYWwoXCJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLWl0YWxpYy5lb3Q/I2llZml4XCIpIGZvcm1hdChcImVtYmVkZGVkLW9wZW50eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL3NvdXJjZS1zYW5zLXByby12MjEtdmlldG5hbWVzZV9sYXRpbl9jeXJpbGxpYy1pdGFsaWMud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLWl0YWxpYy53b2ZmXCIpIGZvcm1hdChcIndvZmZcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLWl0YWxpYy50dGZcIikgZm9ybWF0KFwidHJ1ZXR5cGVcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLWl0YWxpYy5zdmcjU291cmNlX1NhbnNfUHJvXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJTb3VyY2UgU2FucyBQcm9cIjtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogNjAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTYwMC5lb3RcIik7XG4gIHNyYzogbG9jYWwoXCJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTYwMC5lb3Q/I2llZml4XCIpIGZvcm1hdChcImVtYmVkZGVkLW9wZW50eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL3NvdXJjZS1zYW5zLXByby12MjEtdmlldG5hbWVzZV9sYXRpbl9jeXJpbGxpYy02MDAud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTYwMC53b2ZmXCIpIGZvcm1hdChcIndvZmZcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTYwMC50dGZcIikgZm9ybWF0KFwidHJ1ZXR5cGVcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTYwMC5zdmcjU291cmNlX1NhbnNfUHJvXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJTb3VyY2UgU2FucyBQcm9cIjtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogNzAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTcwMC5lb3RcIik7XG4gIHNyYzogbG9jYWwoXCJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTcwMC5lb3Q/I2llZml4XCIpIGZvcm1hdChcImVtYmVkZGVkLW9wZW50eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL3NvdXJjZS1zYW5zLXByby12MjEtdmlldG5hbWVzZV9sYXRpbl9jeXJpbGxpYy03MDAud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTcwMC53b2ZmXCIpIGZvcm1hdChcIndvZmZcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTcwMC50dGZcIikgZm9ybWF0KFwidHJ1ZXR5cGVcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvc291cmNlLXNhbnMtcHJvLXYyMS12aWV0bmFtZXNlX2xhdGluX2N5cmlsbGljLTcwMC5zdmcjU291cmNlX1NhbnNfUHJvXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJOb3RvIFNhbnMgU0NcIjtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogMjAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvbm90by1zYW5zLXNjLXYyNi1sYXRpbl9jaGluZXNlLXNpbXBsaWZpZWQtMjAwLmVvdFwiKTtcbiAgc3JjOiBsb2NhbChcIlwiKSwgdXJsKFwiL28vb3NiLXd3dy1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci9mb250cy9ub3RvLXNhbnMtc2MtdjI2LWxhdGluX2NoaW5lc2Utc2ltcGxpZmllZC0yMDAuZW90PyNpZWZpeFwiKSBmb3JtYXQoXCJlbWJlZGRlZC1vcGVudHlwZVwiKSwgdXJsKFwiL28vb3NiLXd3dy1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci9mb250cy9ub3RvLXNhbnMtc2MtdjI2LWxhdGluX2NoaW5lc2Utc2ltcGxpZmllZC0yMDAud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvbm90by1zYW5zLXNjLXYyNi1sYXRpbl9jaGluZXNlLXNpbXBsaWZpZWQtMjAwLndvZmZcIikgZm9ybWF0KFwid29mZlwiKSwgdXJsKFwiL28vb3NiLXd3dy1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci9mb250cy9ub3RvLXNhbnMtc2MtdjI2LWxhdGluX2NoaW5lc2Utc2ltcGxpZmllZC0yMDAudHRmXCIpIGZvcm1hdChcInRydWV0eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL25vdG8tc2Fucy1zYy12MjYtbGF0aW5fY2hpbmVzZS1zaW1wbGlmaWVkLTIwMC5zdmcjTm90b19TYW5zX1NDXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJOb3RvIFNhbnMgU0NcIjtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogMzAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvbm90by1zYW5zLXNjLXYyNi1sYXRpbl9jaGluZXNlLXNpbXBsaWZpZWQtMzAwLmVvdFwiKTtcbiAgc3JjOiBsb2NhbChcIlwiKSwgdXJsKFwiL28vb3NiLXd3dy1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci9mb250cy9ub3RvLXNhbnMtc2MtdjI2LWxhdGluX2NoaW5lc2Utc2ltcGxpZmllZC0zMDAuZW90PyNpZWZpeFwiKSBmb3JtYXQoXCJlbWJlZGRlZC1vcGVudHlwZVwiKSwgdXJsKFwiL28vb3NiLXd3dy1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci9mb250cy9ub3RvLXNhbnMtc2MtdjI2LWxhdGluX2NoaW5lc2Utc2ltcGxpZmllZC0zMDAud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvbm90by1zYW5zLXNjLXYyNi1sYXRpbl9jaGluZXNlLXNpbXBsaWZpZWQtMzAwLndvZmZcIikgZm9ybWF0KFwid29mZlwiKSwgdXJsKFwiL28vb3NiLXd3dy1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci9mb250cy9ub3RvLXNhbnMtc2MtdjI2LWxhdGluX2NoaW5lc2Utc2ltcGxpZmllZC0zMDAudHRmXCIpIGZvcm1hdChcInRydWV0eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL25vdG8tc2Fucy1zYy12MjYtbGF0aW5fY2hpbmVzZS1zaW1wbGlmaWVkLTMwMC5zdmcjTm90b19TYW5zX1NDXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJOb3RvIFNhbnMgU0NcIjtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogNDAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvbm90by1zYW5zLXNjLXYyNi1sYXRpbl9jaGluZXNlLXNpbXBsaWZpZWQtNDAwLmVvdFwiKTtcbiAgc3JjOiBsb2NhbChcIlwiKSwgdXJsKFwiL28vb3NiLXd3dy1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci9mb250cy9ub3RvLXNhbnMtc2MtdjI2LWxhdGluX2NoaW5lc2Utc2ltcGxpZmllZC00MDAuZW90PyNpZWZpeFwiKSBmb3JtYXQoXCJlbWJlZGRlZC1vcGVudHlwZVwiKSwgdXJsKFwiL28vb3NiLXd3dy1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci9mb250cy9ub3RvLXNhbnMtc2MtdjI2LWxhdGluX2NoaW5lc2Utc2ltcGxpZmllZC00MDAud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvbm90by1zYW5zLXNjLXYyNi1sYXRpbl9jaGluZXNlLXNpbXBsaWZpZWQtNDAwLndvZmZcIikgZm9ybWF0KFwid29mZlwiKSwgdXJsKFwiL28vb3NiLXd3dy1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci9mb250cy9ub3RvLXNhbnMtc2MtdjI2LWxhdGluX2NoaW5lc2Utc2ltcGxpZmllZC00MDAudHRmXCIpIGZvcm1hdChcInRydWV0eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL25vdG8tc2Fucy1zYy12MjYtbGF0aW5fY2hpbmVzZS1zaW1wbGlmaWVkLTQwMC5zdmcjTm90b19TYW5zX1NDXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJOb3RvIFNhbnMgU0NcIjtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogNTAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvbm90by1zYW5zLXNjLXYyNi1sYXRpbl9jaGluZXNlLXNpbXBsaWZpZWQtNTAwLmVvdFwiKTtcbiAgc3JjOiBsb2NhbChcIlwiKSwgdXJsKFwiL28vb3NiLXd3dy1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci9mb250cy9ub3RvLXNhbnMtc2MtdjI2LWxhdGluX2NoaW5lc2Utc2ltcGxpZmllZC01MDAuZW90PyNpZWZpeFwiKSBmb3JtYXQoXCJlbWJlZGRlZC1vcGVudHlwZVwiKSwgdXJsKFwiL28vb3NiLXd3dy1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci9mb250cy9ub3RvLXNhbnMtc2MtdjI2LWxhdGluX2NoaW5lc2Utc2ltcGxpZmllZC01MDAud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvbm90by1zYW5zLXNjLXYyNi1sYXRpbl9jaGluZXNlLXNpbXBsaWZpZWQtNTAwLndvZmZcIikgZm9ybWF0KFwid29mZlwiKSwgdXJsKFwiL28vb3NiLXd3dy1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci9mb250cy9ub3RvLXNhbnMtc2MtdjI2LWxhdGluX2NoaW5lc2Utc2ltcGxpZmllZC01MDAudHRmXCIpIGZvcm1hdChcInRydWV0eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL25vdG8tc2Fucy1zYy12MjYtbGF0aW5fY2hpbmVzZS1zaW1wbGlmaWVkLTUwMC5zdmcjTm90b19TYW5zX1NDXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbkBmb250LWZhY2Uge1xuICBmb250LWZhbWlseTogXCJOb3RvIFNhbnMgU0NcIjtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogNzAwO1xuICBzcmM6IHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvbm90by1zYW5zLXNjLXYyNi1sYXRpbl9jaGluZXNlLXNpbXBsaWZpZWQtNzAwLmVvdFwiKTtcbiAgc3JjOiBsb2NhbChcIlwiKSwgdXJsKFwiL28vb3NiLXd3dy1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci9mb250cy9ub3RvLXNhbnMtc2MtdjI2LWxhdGluX2NoaW5lc2Utc2ltcGxpZmllZC03MDAuZW90PyNpZWZpeFwiKSBmb3JtYXQoXCJlbWJlZGRlZC1vcGVudHlwZVwiKSwgdXJsKFwiL28vb3NiLXd3dy1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci9mb250cy9ub3RvLXNhbnMtc2MtdjI2LWxhdGluX2NoaW5lc2Utc2ltcGxpZmllZC03MDAud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIi9vL29zYi13d3ctZm91bmRhdGlvbnMtdGhlbWUtY29udHJpYnV0b3IvZm9udHMvbm90by1zYW5zLXNjLXYyNi1sYXRpbl9jaGluZXNlLXNpbXBsaWZpZWQtNzAwLndvZmZcIikgZm9ybWF0KFwid29mZlwiKSwgdXJsKFwiL28vb3NiLXd3dy1mb3VuZGF0aW9ucy10aGVtZS1jb250cmlidXRvci9mb250cy9ub3RvLXNhbnMtc2MtdjI2LWxhdGluX2NoaW5lc2Utc2ltcGxpZmllZC03MDAudHRmXCIpIGZvcm1hdChcInRydWV0eXBlXCIpLCB1cmwoXCIvby9vc2Itd3d3LWZvdW5kYXRpb25zLXRoZW1lLWNvbnRyaWJ1dG9yL2ZvbnRzL25vdG8tc2Fucy1zYy12MjYtbGF0aW5fY2hpbmVzZS1zaW1wbGlmaWVkLTcwMC5zdmcjTm90b19TYW5zX1NDXCIpIGZvcm1hdChcInN2Z1wiKTtcbn1cbmJvZHkgLmNvbnRlbnQge1xuICBmb250OiA0MDAgMTZweC8xLjUgXCJTb3VyY2UgU2FucyBQcm9cIiwgVGFob21hLCBcIlRyZWJ1Y2hldCBNU1wiLCBzYW5zLXNlcmlmO1xuICAtbW96LW9zeC1mb250LXNtb290aGluZzogZ3JheXNjYWxlO1xuICAtd2Via2l0LWZvbnQtc21vb3RoaW5nOiBhbnRpYWxpYXNlZDtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICByaWdodDogMDtcbn1cbmJvZHkgLmNvbnRlbnQgYixcbmJvZHkgLmNvbnRlbnQgc3Ryb25nIHtcbiAgZm9udC13ZWlnaHQ6IDcwMDtcbn1cbmJvZHkgLmNvbnRlbnQgYmxvY2txdW90ZSB7XG4gIGZvbnQtc2l6ZTogMS4yNWVtO1xuICBsaW5lLWhlaWdodDogMS4yNTtcbn1cbkBtZWRpYSAobWF4LXdpZHRoOiA5NzlweCkge1xuICBib2R5IC5jb250ZW50IGJsb2NrcXVvdGUge1xuICAgIGZvbnQtc2l6ZTogMS41ZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgfVxufVxuYm9keSAuY29udGVudCAubG9uZy1mb3JtIHtcbiAgZm9udC1zaXplOiAxLjI1ZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjU7XG59XG5ib2R5IC5jb250ZW50IC5sb25nLWZvcm0gYTpub3QoLmJ0bikge1xuICB0ZXh0LWRlY29yYXRpb246IHVuZGVybGluZTtcbn1cbmJvZHkgLmNvbnRlbnQgLmxvbmctZm9ybSBoMiB7XG4gIGZvbnQtc2l6ZTogMS41ZW07XG4gIGZvbnQtd2VpZ2h0OiA0MDA7XG4gIG1hcmdpbi10b3A6IDFlbTtcbn1cbmJvZHkgLmNvbnRlbnQgLmxvbmctZm9ybSBoMjpmaXJzdC1jaGlsZCB7XG4gIG1hcmdpbi10b3A6IDAuMjVlbTtcbn1cbmJvZHkgLmNvbnRlbnQgLmxvbmctZm9ybSBoMyB7XG4gIGZvbnQtc2l6ZTogMS4yNWVtO1xuICBmb250LXdlaWdodDogNjAwO1xuICBtYXJnaW4tdG9wOiAxZW07XG59XG5ib2R5IC5jb250ZW50IC5sb25nLWZvcm0gaDQge1xuICBmb250LXNpemU6IDEuMmVtO1xuICBtYXJnaW4tdG9wOiAxZW07XG59XG5ib2R5IC5jb250ZW50IC5sb25nLWZvcm0gbGkge1xuICBsaW5lLWhlaWdodDogaW5oZXJpdDtcbiAgbWFyZ2luLWJvdHRvbTogMWVtO1xufVxuYm9keSAuY29udGVudCAubG9uZy1mb3JtIG9sLFxuYm9keSAuY29udGVudCAubG9uZy1mb3JtIHA6bm90KC5zbWFsbC1jYXBzKSxcbmJvZHkgLmNvbnRlbnQgLmxvbmctZm9ybSB1bCB7XG4gIGZvbnQtZmFtaWx5OiBcIlNvdXJjZSBTZXJpZiBQcm9cIiwgR2VvcmdpYSwgQ2FtYnJpYSwgXCJUaW1lcyBOZXcgUm9tYW5cIiwgVGltZXMsIHNlcmlmO1xuICBmb250LXdlaWdodDogNDAwO1xuICBtYXJnaW4tYm90dG9tOiAxZW07XG59XG5ib2R5IC5jb250ZW50IC5sb25nLWZvcm0gcC5pbnRyb2R1Y3Rpb24ge1xuICBmb250LXNpemU6IDEuMmVtO1xufVxuYm9keSAuY29udGVudCAubG9uZy1mb3JtIHVsOm5vdCgudW5zdHlsZWQpIHtcbiAgbGlzdC1zdHlsZTogbm9uZTtcbn1cbmJvZHkgLmNvbnRlbnQgLmxvbmctZm9ybSB1bDpub3QoLnVuc3R5bGVkKSBsaTpiZWZvcmUge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1uZXV0cmFsLTUpO1xuICBib3JkZXItcmFkaXVzOiAwLjI1ZW07XG4gIGNvbnRlbnQ6IFwiXCI7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgaGVpZ2h0OiAwLjI1ZW07XG4gIG1hcmdpbjogMCAwLjVlbSAwLjI1ZW0gLTFlbTtcbiAgd2lkdGg6IDAuMjVlbTtcbn1cbmJvZHkgLmNvbnRlbnQgLmxvbmctZm9ybSAubG9uZy1mb3JtLXRpdGxlIHtcbiAgbWFyZ2luLWJvdHRvbTogY2FsYygyZW0gKyA0cHgpO1xuICBwb3NpdGlvbjogcmVsYXRpdmU7XG59XG5ib2R5IC5jb250ZW50IC5sb25nLWZvcm0gLmxvbmctZm9ybS10aXRsZTphZnRlciB7XG4gIGJhY2tncm91bmQ6ICMxMzQxOTQ7XG4gIGJvdHRvbTogLTFlbTtcbiAgY29udGVudDogXCJcIjtcbiAgZGlzcGxheTogYmxvY2s7XG4gIGhlaWdodDogNHB4O1xuICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gIHdpZHRoOiA1NnB4O1xufVxuQG1lZGlhIChtaW4td2lkdGg6IDc2OHB4KSBhbmQgKG1heC13aWR0aDogOTc5cHgpIHtcbiAgYm9keSAuY29udGVudCAubG9uZy1mb3JtIGgyIHtcbiAgICBmb250LXNpemU6IDEuNGVtO1xuICB9XG4gIGJvZHkgLmNvbnRlbnQgLmxvbmctZm9ybSBoMyB7XG4gICAgZm9udC1zaXplOiAxLjJlbTtcbiAgfVxufVxuQG1lZGlhIChtYXgtd2lkdGg6IDc2N3B4KSB7XG4gIGJvZHkgLmNvbnRlbnQgLmxvbmctZm9ybSB7XG4gICAgZm9udC1zaXplOiAxLjFlbTtcbiAgICBsaW5lLWhlaWdodDogMS42ZW07XG4gIH1cbiAgYm9keSAuY29udGVudCAubG9uZy1mb3JtIGgyIHtcbiAgICBmb250LXNpemU6IDEuMmVtO1xuICAgIGZvbnQtd2VpZ2h0OiA2MDA7XG4gIH1cbiAgYm9keSAuY29udGVudCAubG9uZy1mb3JtIGgzIHtcbiAgICBmb250LXNpemU6IDEuMTI1ZW07XG4gIH1cbn1cbmJvZHkgLmNvbnRlbnQgLnBhZ2UtaGVhZGluZyAucHJlaGVhZGluZyxcbmJvZHkgLmNvbnRlbnQgLnByZWhlYWRpbmcge1xuICBmb250LXNpemU6IDFlbTtcbn1cbmJvZHkgLmNvbnRlbnQgLnN1YmhlYWRpbmcge1xuICBjb2xvcjogdmFyKC0tbmV1dHJhbC01KTtcbiAgZm9udC13ZWlnaHQ6IDQwMDtcbn1cbmJvZHkgLmNvbnRlbnQgLnNvdXJjZS10ZXh0IHtcbiAgY29sb3I6IHZhcigtLW5ldXRyYWwtNSk7XG4gIGZvbnQtc2l6ZTogMC43NWVtO1xuICBtYXJnaW46IDAuNWVtIDA7XG59XG5cbi5hc3BlY3QtcmF0aW8taXRlbS1mbHVzaC0xMTAge1xuICBtYXgtd2lkdGg6IG5vbmU7XG4gIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgd2lkdGg6IDExMCU7XG59XG5cbi5hc3BlY3QtcmF0aW8taXRlbS1mbHVzaC0xMjAge1xuICBtYXgtd2lkdGg6IG5vbmU7XG4gIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgd2lkdGg6IDEyMCU7XG59XG5cbi5hc3BlY3QtcmF0aW8taXRlbS1mbHVzaC0xMzAge1xuICBtYXgtd2lkdGg6IG5vbmU7XG4gIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgd2lkdGg6IDEzMCU7XG59XG5cbi5hc3BlY3QtcmF0aW8taXRlbS12ZXJ0aWNhbC1mbHVzaC0xMTAge1xuICBoZWlnaHQ6IDExMCU7XG4gIG1heC1oZWlnaHQ6IG5vbmU7XG4gIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbn1cblxuLmFzcGVjdC1yYXRpby1pdGVtLXZlcnRpY2FsLWZsdXNoLTEyMCB7XG4gIGhlaWdodDogMTIwJTtcbiAgbWF4LWhlaWdodDogbm9uZTtcbiAgcG9zaXRpb246IGFic29sdXRlO1xufVxuXG4uYXNwZWN0LXJhdGlvLWl0ZW0tdmVydGljYWwtZmx1c2gtMTMwIHtcbiAgaGVpZ2h0OiAxMzAlO1xuICBtYXgtaGVpZ2h0OiBub25lO1xuICBwb3NpdGlvbjogYWJzb2x1dGU7XG59XG5cbi5hc3BlY3QtcmF0aW8tb2JqZWN0LWZpdC1jb3ZlciB7XG4gIGJhY2tncm91bmQtcG9zaXRpb246IGNlbnRlcjtcbiAgYmFja2dyb3VuZC1yZXBlYXQ6IG5vLXJlcGVhdDtcbiAgYmFja2dyb3VuZC1zaXplOiBjb3Zlcjtcbn1cbi5hc3BlY3QtcmF0aW8tb2JqZWN0LWZpdC1jb3ZlciAuZnJhZ21lbnRzLWltYWdlLWRpdixcbi5hc3BlY3QtcmF0aW8tb2JqZWN0LWZpdC1jb3ZlciAuZnJhZ21lbnRzLWRpdixcbi5hc3BlY3QtcmF0aW8tb2JqZWN0LWZpdC1jb3ZlciAuZnJhZ21lbnRzLWVkaXRvcl9fZWRpdGFibGVbdHlwZT1pbWFnZV0ge1xuICBoZWlnaHQ6IDEwMCU7XG4gIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgd2lkdGg6IDEwMCU7XG59XG4uYXNwZWN0LXJhdGlvLW9iamVjdC1maXQtY292ZXIgLmZyYWdtZW50cy1pbWFnZS1kaXYgaW1nLFxuLmFzcGVjdC1yYXRpby1vYmplY3QtZml0LWNvdmVyIC5mcmFnbWVudHMtZGl2IGltZyxcbi5hc3BlY3QtcmF0aW8tb2JqZWN0LWZpdC1jb3ZlciAuZnJhZ21lbnRzLWVkaXRvcl9fZWRpdGFibGVbdHlwZT1pbWFnZV0gaW1nIHtcbiAgaGVpZ2h0OiAxMDAlO1xuICBsZWZ0OiAwO1xuICBvYmplY3QtZml0OiBjb3ZlcjtcbiAgcG9zaXRpb246IGFic29sdXRlO1xuICB3aWR0aDogMTAwJTtcbn1cblxuLm9zYi1zdmctLW1vbm9zcGFjZWQge1xuICBoZWlnaHQ6IDEwMCU7XG4gIHdpZHRoOiAxMDAlO1xufVxuLm9zYi1zdmctLW1vbm9zcGFjZWQgLmZyYWdtZW50cy1kaXYsXG4ub3NiLXN2Zy0tbW9ub3NwYWNlZCAuZnJhZ21lbnRzLWVkaXRvcl9fZWRpdGFibGVbdHlwZT1odG1sXSB7XG4gIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gIGRpc3BsYXk6IGZsZXg7XG4gIGhlaWdodDogMTAwJTtcbiAgdGV4dC1hbGlnbjogY2VudGVyO1xuICB3aWR0aDogMTAwJTtcbiAgd29yZC13cmFwOiBicmVhay13b3JkO1xufVxuLm9zYi1zdmctLW1vbm9zcGFjZWQgLmZyYWdtZW50cy1kaXYgc3ZnLFxuLm9zYi1zdmctLW1vbm9zcGFjZWQgLmZyYWdtZW50cy1lZGl0b3JfX2VkaXRhYmxlW3R5cGU9aHRtbF0gc3ZnIHtcbiAgaGVpZ2h0OiBhdXRvO1xuICB3aWR0aDogMTAwJTtcbn1cbi5vc2Itc3ZnLS1tb25vc3BhY2VkIC5odG1sLXBsYWNlaG9sZGVyIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogI2E3YTliYztcbiAgZGlzcGxheTogZmxleDtcbiAgaGVpZ2h0OiAxMDAlO1xuICBqdXN0aWZ5LWNvbnRlbnQ6IGNlbnRlcjtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICB3aWR0aDogMTAwJTtcbn1cbi5vc2Itc3ZnLS1tb25vc3BhY2VkIC5odG1sLXBsYWNlaG9sZGVyLXRleHQge1xuICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gIHRvcDogNTAlO1xuICB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoLTUwJSk7XG59XG5cbkBtZWRpYSAobWF4LXdpZHRoOiA1OTlweCkge1xuICAuaGlkZS1waG9uZSB7XG4gICAgZGlzcGxheTogbm9uZSAhaW1wb3J0YW50O1xuICB9XG59XG5cbkBtZWRpYSAobWluLXdpZHRoOiA2MDBweCkgYW5kIChtYXgtd2lkdGg6IDg5OXB4KSB7XG4gIC5oaWRlLXRhYmxldC1wb3J0cmFpdCB7XG4gICAgZGlzcGxheTogbm9uZSAhaW1wb3J0YW50O1xuICB9XG59XG5cbkBtZWRpYSAobWluLXdpZHRoOiA5MDBweCkgYW5kIChtYXgtd2lkdGg6IDExOTlweCkge1xuICAuaGlkZS10YWJsZXQtbGFuZHNjYXBlIHtcbiAgICBkaXNwbGF5OiBub25lICFpbXBvcnRhbnQ7XG4gIH1cbn1cblxuQG1lZGlhIChtaW4td2lkdGg6IDEyMDBweCkgYW5kIChtYXgtd2lkdGg6IDE3OTlweCkge1xuICAuaGlkZS1kZXNrdG9wIHtcbiAgICBkaXNwbGF5OiBub25lICFpbXBvcnRhbnQ7XG4gIH1cbn1cblxuQG1lZGlhIChtaW4td2lkdGg6IDE4MDBweCkge1xuICAuaGlkZS1sYXJnZS1kZXNrdG9wLXVwIHtcbiAgICBkaXNwbGF5OiBub25lICFpbXBvcnRhbnQ7XG4gIH1cbn1cblxuLmhvdmVyLXRleHQtZGVjb3JhdGlvbi1ub25lOmhvdmVyIHtcbiAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xufVxuXG4uY29udGVudCAuYWxpZ24tY2VudGVyIHtcbiAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbn1cbi5jb250ZW50IC5hbGlnbi1zdGFydCB7XG4gIGFsaWduLWl0ZW1zOiBmbGV4LXN0YXJ0O1xufVxuLmNvbnRlbnQgLmFsaWduLWNvbnRlbnQtY2VudGVyIHtcbiAgYWxpZ24tY29udGVudDogY2VudGVyO1xufVxuLmNvbnRlbnQgLmJsb2NrLWNvbnRhaW5lciB7XG4gIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gIGRpc3BsYXk6IGZsZXg7XG4gIGZsZXgtd3JhcDogd3JhcDtcbiAgcGFkZGluZzogMWVtO1xufVxuLmNvbnRlbnQgLmJsb2NrLWNvbnRhaW5lciAuYmxvY2sge1xuICBib3gtc2l6aW5nOiBib3JkZXItYm94O1xufVxuLmNvbnRlbnQgLmJsb2NrLWNvbnRhaW5lciAuYmxvY2sucHJldmlldy1ibG9jayB7XG4gIHBhZGRpbmc6IDAuNWVtO1xuICB3aWR0aDogMjUlO1xufVxuLmNvbnRlbnQgLmJsb2NrLWNvbnRhaW5lciAuYmxvY2sucHJldmlldy1ibG9jayBhIHtcbiAgYm9yZGVyOiAxcHggc29saWQ7XG4gIGJvcmRlci1yYWRpdXM6IDRweDtcbiAgZGlzcGxheTogYmxvY2s7XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbn1cbkBtZWRpYSAobWluLXdpZHRoOiA3NjhweCkgYW5kIChtYXgtd2lkdGg6IDk3OXB4KSB7XG4gIC5jb250ZW50IC5ibG9jay1jb250YWluZXIgLmJsb2NrLnByZXZpZXctYmxvY2sge1xuICAgIHdpZHRoOiAzMy4zMzMlO1xuICB9XG59XG4uY29udGVudCAuYmxvY2stY29udGFpbmVyIC5ibG9jay5yaWdodC1ibG9jayB7XG4gIHBhZGRpbmctbGVmdDogMWVtO1xufVxuQG1lZGlhIChtYXgtd2lkdGg6IDc2N3B4KSB7XG4gIC5jb250ZW50IC5ibG9jay1jb250YWluZXIgLmJsb2NrIHtcbiAgICB3aWR0aDogMTAwJSAhaW1wb3J0YW50O1xuICB9XG59XG4uY29udGVudCAuYm9yZGVyLWJvdHRvbSB7XG4gIGJvcmRlci1ib3R0b20tc3R5bGU6IHNvbGlkO1xuICBib3JkZXItYm90dG9tLXdpZHRoOiAxcHg7XG59XG4uY29udGVudCAuYm9yZGVyLWxlZnQge1xuICBib3JkZXItbGVmdC1zdHlsZTogc29saWQ7XG4gIGJvcmRlci1sZWZ0LXdpZHRoOiAxcHg7XG59XG4uY29udGVudCAuYm9yZGVyLXJpZ2h0IHtcbiAgYm9yZGVyLXJpZ2h0LXN0eWxlOiBzb2xpZDtcbiAgYm9yZGVyLXJpZ2h0LXdpZHRoOiAxcHg7XG59XG4uY29udGVudCAuYm9yZGVyLXRvcCB7XG4gIGJvcmRlci10b3Atc3R5bGU6IHNvbGlkO1xuICBib3JkZXItdG9wLXdpZHRoOiAxcHg7XG59XG4uY29udGVudCAuZmxleCB7XG4gIGRpc3BsYXk6IGZsZXg7XG59XG4uY29udGVudCAuZmxleC1jb2x1bW4ge1xuICBmbGV4LWRpcmVjdGlvbjogY29sdW1uO1xufVxuLmNvbnRlbnQgLmZsZXgtY29sdW1uLXJldmVyc2Uge1xuICBmbGV4LWRpcmVjdGlvbjogY29sdW1uLXJldmVyc2U7XG59XG4uY29udGVudCAuZmxleC1yb3cge1xuICBmbGV4LWRpcmVjdGlvbjogcm93O1xufVxuLmNvbnRlbnQgLmZsZXgtcm93LXJldmVyc2Uge1xuICBmbGV4LWRpcmVjdGlvbjogcm93LXJldmVyc2U7XG59XG4uY29udGVudCAuZm9udC13ZWlnaHQtbGlnaHRlciB7XG4gIGZvbnQtd2VpZ2h0OiAyMDA7XG59XG4uY29udGVudCAuZm9udC13ZWlnaHQtYm9sZCB7XG4gIGZvbnQtd2VpZ2h0OiA2MDA7XG59XG4uY29udGVudCAuZnVsbC1zY3JlZW4ge1xuICBtYXgtd2lkdGg6IG5vbmUgIWltcG9ydGFudDtcbn1cbi5jb250ZW50IC5mdWxsLXNjcmVlbiAucG9ydGxldC1jb2x1bW4ge1xuICBtYXgtd2lkdGg6IG5vbmU7XG59XG4uY29udGVudCAuanVzdGlmeS1jZW50ZXIge1xuICBqdXN0aWZ5LWNvbnRlbnQ6IGNlbnRlcjtcbn1cbi5jb250ZW50IC5qdXN0aWZ5LWVuZCB7XG4gIGp1c3RpZnktY29udGVudDogZmxleC1lbmQ7XG59XG4uY29udGVudCAuanVzdGlmeS1zcGFjZS1hcm91bmQge1xuICBqdXN0aWZ5LWNvbnRlbnQ6IHNwYWNlLWFyb3VuZDtcbn1cbi5jb250ZW50IC5qdXN0aWZ5LXNwYWNlLWJldHdlZW4ge1xuICBqdXN0aWZ5LWNvbnRlbnQ6IHNwYWNlLWJldHdlZW47XG59XG4uY29udGVudCAuanVzdGlmeS1zdGFydCB7XG4gIGp1c3RpZnktY29udGVudDogZmxleC1zdGFydDtcbn1cbi5jb250ZW50IC5tYXgtZnVsbCxcbi5jb250ZW50IC5tYXgtbGcsXG4uY29udGVudCAubWF4LW1lZCxcbi5jb250ZW50IC5tYXgtc20ge1xuICBib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICBtYXJnaW46IDAgYXV0bztcbiAgcGFkZGluZzogMCAxZW07XG59XG4uY29udGVudCAubWF4LWZ1bGwge1xuICBtYXgtd2lkdGg6IDEyMDBweDtcbn1cbi5jb250ZW50IC5tYXgtbGcge1xuICBtYXgtd2lkdGg6IDk2MHB4O1xufVxuLmNvbnRlbnQgLm1heC1tZWQge1xuICBtYXgtd2lkdGg6IDcyMHB4O1xufVxuLmNvbnRlbnQgLm1heC1zbSB7XG4gIG1heC13aWR0aDogNDgwcHg7XG59XG4uY29udGVudCAubm8tcGFkZGluZyB7XG4gIHBhZGRpbmc6IDA7XG59XG4uY29udGVudCAubm8tcGFkZGluZy1ob3Jpem9udGFsIHtcbiAgcGFkZGluZy1sZWZ0OiAwICFpbXBvcnRhbnQ7XG4gIHBhZGRpbmctcmlnaHQ6IDAgIWltcG9ydGFudDtcbn1cbi5jb250ZW50IC5uby1wYWRkaW5nLXZlcnRpY2FsIHtcbiAgcGFkZGluZy1ib3R0b206IDAgIWltcG9ydGFudDtcbiAgcGFkZGluZy10b3A6IDAgIWltcG9ydGFudDtcbn1cbi5jb250ZW50IC5zbWFsbC1wYWRkaW5nIHtcbiAgcGFkZGluZzogMC41ZW07XG59XG4uY29udGVudCAuc21hbGwtcGFkZGluZy1ob3Jpem9udGFsIHtcbiAgcGFkZGluZy1sZWZ0OiAwLjVlbTtcbiAgcGFkZGluZy1yaWdodDogMC41ZW07XG59XG4uY29udGVudCAuc21hbGwtcGFkZGluZy12ZXJ0aWNhbCB7XG4gIHBhZGRpbmctYm90dG9tOiAwLjVlbTtcbiAgcGFkZGluZy10b3A6IDAuNWVtO1xufVxuLmNvbnRlbnQgLnN0YW5kYXJkLXBhZGRpbmcge1xuICBwYWRkaW5nOiAxZW07XG59XG4uY29udGVudCAuc3RhbmRhcmQtcGFkZGluZy1ob3Jpem9udGFsIHtcbiAgcGFkZGluZy1sZWZ0OiAxZW07XG4gIHBhZGRpbmctcmlnaHQ6IDFlbTtcbn1cbi5jb250ZW50IC5zdGFuZGFyZC1wYWRkaW5nLXZlcnRpY2FsIHtcbiAgcGFkZGluZy1ib3R0b206IDFlbTtcbiAgcGFkZGluZy10b3A6IDFlbTtcbn1cblxuYm9keS5kYXJrLFxuLmRhcmsgYm9keSB7XG4gIGJhY2tncm91bmQtaW1hZ2U6IGxpbmVhci1ncmFkaWVudCg5NS45MmRlZywgdmFyKC0tcHJpbWFyeS1kYXJrKSAyMC42MSUsIHZhcigtLXByaW1hcnkpIDEwMCUpO1xufVxuYm9keS5kYXJrIC5wYWdlLWVkaXRvcl9fbGF5b3V0LXZpZXdwb3J0LFxuYm9keS5kYXJrIC5wYWdlLWVkaXRvcl9fbGF5b3V0LXZpZXdwb3J0X19yZXNpemVyLFxuLmRhcmsgYm9keSAucGFnZS1lZGl0b3JfX2xheW91dC12aWV3cG9ydCxcbi5kYXJrIGJvZHkgLnBhZ2UtZWRpdG9yX19sYXlvdXQtdmlld3BvcnRfX3Jlc2l6ZXIge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbn1cblxuLmRhcmsge1xuICBjb2xvcjogdmFyKC0td2hpdGUpO1xufVxuXG4ubGlnaHQge1xuICBjb2xvcjogdmFyKC0tYmxhY2spO1xufVxuXG4uY29udGVudCAubGF5b3V0LWNvbnRlbnQge1xuICBmb250OiA0MDAgMTZweC8xLjUgXCJTb3VyY2UgU2FucyBQcm9cIiwgVGFob21hLCBcIlRyZWJ1Y2hldCBNU1wiLCBzYW5zLXNlcmlmO1xufVxuLmNvbnRlbnQgLmxheW91dC1jb250ZW50ICosXG4uY29udGVudCAubGF5b3V0LWNvbnRlbnQgKjo6YmVmb3JlLFxuLmNvbnRlbnQgLmxheW91dC1jb250ZW50ICo6OmFmdGVyIHtcbiAgYm94LXNpemluZzogYm9yZGVyLWJveCAhaW1wb3J0YW50O1xufVxuQG1lZGlhIChtaW4td2lkdGg6IDYwMHB4KSB7XG4gIC5jb250ZW50IC5sYXlvdXQtY29udGVudCAudGV4dC1jZW50ZXItdGFibGV0LXBvcnRyYWl0LXVwIHtcbiAgICB0ZXh0LWFsaWduOiBjZW50ZXI7XG4gIH1cbn1cblxuLmNvbnRlbnQgLmxheW91dC1jb250ZW50IC5mcmFnbWVudHMtZWRpdG9yLXNpZGViYXItc2VjdGlvbl9fdGl0bGUge1xuICBmb250LXNpemU6IDE4cHg7XG4gIGZvbnQtd2VpZ2h0OiA2MDA7XG4gIG1hcmdpbjogMzJweCAwIDI0cHggMDtcbn1cblxuLmZyYWdtZW50cy1lZGl0b3JfX2VkaXRhYmxlW3R5cGU9dGV4dF0sXG4uZnJhZ21lbnRzLWVkaXRvcl9fZWRpdGFibGVbdHlwZT1yaWNoLXRleHRdIHtcbiAgbWF4LXdpZHRoOiAxMDAlO1xuICB3b3JkLXdyYXA6IGJyZWFrLXdvcmQ7XG59XG5cbi56aF9DTiAuY29udGVudCAubGF5b3V0LWNvbnRlbnQge1xuICBmb250LWZhbWlseTogXCJTb3VyY2UgU2FucyBQcm9cIiwgXCJOb3RvIFNhbnMgU0NcIiwgVGFob21hLCBcIlRyZWJ1Y2hldCBNU1wiLCBzYW5zLXNlcmlmO1xufVxuXG4uYmctZ3JhZGllbnQtYmx1ZS1wdXJwbGUge1xuICBiYWNrZ3JvdW5kOiBsaW5lYXItZ3JhZGllbnQoOTBkZWcsICMwMTYwZjYgMC40NiUsICM3MjBiZGUgMTAwJSk7XG59XG5cbi5iZy1ncmFkaWVudC1ibHVlLXJlZCB7XG4gIGJhY2tncm91bmQ6IGxpbmVhci1ncmFkaWVudCg0NWRlZywgIzAxNjBmNiAwJSwgI2Y2MGM1NiAxMDAlKTtcbn1cblxuLmJnLWdyYWRpZW50LXB1cnBsZS1ibHVlIHtcbiAgYmFja2dyb3VuZDogbGluZWFyLWdyYWRpZW50KDE4MGRlZywgIzcxMGNkZiAwJSwgIzI0NDZlZiAxMTAyLjA4JSk7XG59XG5cbi5wb3J0bGV0IHtcbiAgbWFyZ2luLWJvdHRvbTogMDtcbn1cblxuLm9zYi1pY29uIHtcbiAgZmlsbDogY3VycmVudENvbG9yO1xuICBoZWlnaHQ6IDEuNXJlbTtcbiAgd2lkdGg6IDEuNXJlbTtcbn1cblxuLm9zYi1pY29uLS1zY2FsZSB7XG4gIGhlaWdodDogMS41ZW07XG4gIHdpZHRoOiAxLjVlbTtcbn1cblxuLm9zYi1pY29uLS1jb250ZW50LWVkZ2Uge1xuICBwYWRkaW5nOiA2cHg7XG59XG5cbi5vc2ItaW5saW5lLWxpbmsge1xuICBjb2xvcjogdmFyKC0tYWN0aW9uLWRlZmF1bHQpO1xuICBmb250LXNpemU6IDE4cHg7XG59XG4ub3NiLWlubGluZS1saW5rOnZpc2l0ZWQge1xuICBjb2xvcjogdmFyKC0tYWN0aW9uLXZpc2l0ZWQpO1xufVxuLm9zYi1pbmxpbmUtbGluazpob3ZlciB7XG4gIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdC1ob3Zlcik7XG59XG4ub3NiLWlubGluZS1saW5rOmZvY3VzLCAub3NiLWlubGluZS1saW5rLm9zYi1idG4tLWZvY3VzIHtcbiAgY29sb3I6IHZhcigtLWFjdGlvbi1kZWZhdWx0LWhvdmVyKTtcbn1cbi5vc2ItaW5saW5lLWxpbms6YWN0aXZlLCAub3NiLWlubGluZS1saW5rLm9zYi1idG4tLWFjdGl2ZSB7XG4gIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdC1hY3RpdmUpO1xufVxuLm9zYi1pbmxpbmUtbGluazpkaXNhYmxlZCwgLm9zYi1pbmxpbmUtbGluay5vc2ItYnRuLS1kaXNhYmxlZCB7XG4gIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdCk7XG59XG4ub3NiLWlubGluZS1saW5rLS1zZWNvbmRhcnkge1xuICBjb2xvcjogdmFyKC0tbmV1dHJhbC01KTtcbiAgZm9udC1zaXplOiAxOHB4O1xuICB0ZXh0LWRlY29yYXRpb246IHVuZGVybGluZTtcbn1cbi5vc2ItaW5saW5lLWxpbmstLXNlY29uZGFyeTp2aXNpdGVkIHtcbiAgY29sb3I6IHZhcigtLW5ldXRyYWwtNSk7XG59XG4ub3NiLWlubGluZS1saW5rLS1zZWNvbmRhcnk6aG92ZXIge1xuICBjb2xvcjogdmFyKC0tbmV1dHJhbC01KTtcbn1cbi5vc2ItaW5saW5lLWxpbmstLXNlY29uZGFyeTpmb2N1cywgLm9zYi1pbmxpbmUtbGluay0tc2Vjb25kYXJ5Lm9zYi1idG4tLWZvY3VzIHtcbiAgY29sb3I6IHZhcigtLW5ldXRyYWwtNSk7XG59XG4ub3NiLWlubGluZS1saW5rLS1zZWNvbmRhcnk6YWN0aXZlLCAub3NiLWlubGluZS1saW5rLS1zZWNvbmRhcnkub3NiLWJ0bi0tYWN0aXZlIHtcbiAgY29sb3I6IHZhcigtLW5ldXRyYWwtNSk7XG59XG4ub3NiLWlubGluZS1saW5rLS1zZWNvbmRhcnk6ZGlzYWJsZWQsIC5vc2ItaW5saW5lLWxpbmstLXNlY29uZGFyeS5vc2ItYnRuLS1kaXNhYmxlZCB7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTUpO1xufVxuLm9zYi1pbmxpbmUtbGluay0tbGlnaHQge1xuICBjb2xvcjogcmdiYSh2YXIoLS13aGl0ZSksIDAuNyk7XG59XG4ub3NiLWlubGluZS1saW5rLS1saWdodDp2aXNpdGVkIHtcbiAgY29sb3I6IHJnYmEodmFyKC0td2hpdGUpLCAwLjcpO1xufVxuLm9zYi1pbmxpbmUtbGluay0tbGlnaHQ6aG92ZXIge1xuICBjb2xvcjogcmdiYSh2YXIoLS13aGl0ZSksIDAuNyk7XG59XG4ub3NiLWlubGluZS1saW5rLS1saWdodDpmb2N1cywgLm9zYi1pbmxpbmUtbGluay0tbGlnaHQub3NiLWJ0bi0tZm9jdXMge1xuICBjb2xvcjogcmdiYSh2YXIoLS13aGl0ZSksIDAuNyk7XG59XG4ub3NiLWlubGluZS1saW5rLS1saWdodDphY3RpdmUsIC5vc2ItaW5saW5lLWxpbmstLWxpZ2h0Lm9zYi1idG4tLWFjdGl2ZSB7XG4gIGNvbG9yOiByZ2JhKHZhcigtLXdoaXRlKSwgMC43KTtcbn1cbi5vc2ItaW5saW5lLWxpbmstLWxpZ2h0OmRpc2FibGVkLCAub3NiLWlubGluZS1saW5rLS1saWdodC5vc2ItYnRuLS1kaXNhYmxlZCB7XG4gIGNvbG9yOiByZ2JhKHZhcigtLXdoaXRlKSwgMC43KTtcbn1cbi5vc2ItaW5saW5lLWxpbmstLXVuZGVybGluZSB7XG4gIHRleHQtZGVjb3JhdGlvbjogdW5kZXJsaW5lO1xufVxuLm9zYi1pbmxpbmUtbGluay0tdW5kZXJsaW5lOmhvdmVyIHtcbiAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xufVxuLm9zYi1yZXR1cm4tbGluayB7XG4gIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICBib3JkZXItd2lkdGg6IDA7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTUpO1xuICBkaXNwbGF5OiBpbmxpbmUtZmxleDtcbiAgZm9udC1zaXplOiAwLjlyZW07XG4gIGxpbmUtaGVpZ2h0OiAyN3B4O1xuICBtYXgtd2lkdGg6IDEwMCU7XG4gIHBhZGRpbmc6IDA7XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgd29yZC13cmFwOiBicmVhay13b3JkO1xufVxuLm9zYi1yZXR1cm4tbGluazp2aXNpdGVkIHtcbiAgY29sb3I6IHZhcigtLW5ldXRyYWwtNSk7XG59XG4ub3NiLXJldHVybi1saW5rOmhvdmVyIHtcbiAgY29sb3I6IHZhcigtLW5ldXRyYWwtMyk7XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbn1cbi5vc2ItcmV0dXJuLWxpbms6Zm9jdXMsIC5vc2ItcmV0dXJuLWxpbmsub3NiLWJ0bi0tZm9jdXMge1xuICBjb2xvcjogdmFyKC0tbmV1dHJhbC0zKTtcbn1cbi5vc2ItcmV0dXJuLWxpbms6YWN0aXZlLCAub3NiLXJldHVybi1saW5rLm9zYi1idG4tLWFjdGl2ZSB7XG4gIGNvbG9yOiB2YXIoLS1ibGFjayk7XG59XG4ub3NiLXJldHVybi1saW5rOmRpc2FibGVkLCAub3NiLXJldHVybi1saW5rLm9zYi1idG4tLWRpc2FibGVkIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTUpO1xufVxuLm9zYi1yZXR1cm4tbGluayA+IGRpdiB7XG4gIGRpc3BsYXk6IGlubGluZTtcbn1cbi5vc2ItcmV0dXJuLWxpbmsgPiBzdmcge1xuICBmbGV4LXNocmluazogMDtcbiAgd2lkdGg6IDEuNWVtO1xufVxuXG4ub3NiLWN0YSB7XG4gIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICBib3JkZXItd2lkdGg6IDA7XG4gIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdCk7XG4gIGRpc3BsYXk6IGlubGluZS1mbGV4O1xuICBmb250LXNpemU6IDEuMTI1cmVtO1xuICBmb250LXdlaWdodDogNjAwO1xuICBsaW5lLWhlaWdodDogMjdweDtcbiAgbWF4LXdpZHRoOiAxMDAlO1xuICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gIHdvcmQtd3JhcDogYnJlYWstd29yZDtcbn1cbi5vc2ItY3RhOnZpc2l0ZWQge1xuICBjb2xvcjogdmFyKC0tYWN0aW9uLXZpc2l0ZWQpO1xufVxuLm9zYi1jdGE6aG92ZXIge1xuICBjb2xvcjogdmFyKC0tYWN0aW9uLWRlZmF1bHQtaG92ZXIpO1xuICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG59XG4ub3NiLWN0YTpmb2N1cywgLm9zYi1jdGEub3NiLWJ0bi0tZm9jdXMge1xuICBjb2xvcjogdmFyKC0tYWN0aW9uLWRlZmF1bHQtaG92ZXIpO1xufVxuLm9zYi1jdGE6YWN0aXZlLCAub3NiLWN0YS5vc2ItYnRuLS1hY3RpdmUge1xuICBjb2xvcjogdmFyKC0tYWN0aW9uLWRlZmF1bHQtYWN0aXZlKTtcbn1cbi5vc2ItY3RhOmRpc2FibGVkLCAub3NiLWN0YS5vc2ItYnRuLS1kaXNhYmxlZCB7XG4gIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICBjb2xvcjogdmFyKC0tYWN0aW9uLWRlZmF1bHQpO1xufVxuLm9zYi1jdGEgPiBkaXYge1xuICBkaXNwbGF5OiBpbmxpbmU7XG59XG4ub3NiLWN0YSA+IHN2ZyB7XG4gIGZsZXgtc2hyaW5rOiAwO1xuICBtYXJnaW4tdG9wOiAzcHg7XG59XG4ub3NiLWN0YSAub3NiLWljb24tLWNvbnRlbnQtZWRnZS5vc2ItaWNvbi0tc2NhbGUge1xuICBtYXJnaW4tbGVmdDogLTRweDtcbiAgcGFkZGluZzogN3B4O1xufVxuXG4ub3NiLWN0YS0tYW5pbWF0ZTpob3ZlciA+IHN2ZzpmaXJzdC1jaGlsZCB7XG4gIHRyYW5zZm9ybTogdHJhbnNsYXRlWCgtMC4yNXJlbSk7XG59XG4ub3NiLWN0YS0tYW5pbWF0ZTpob3ZlciA+IHN2ZzpsYXN0LWNoaWxkIHtcbiAgdHJhbnNmb3JtOiB0cmFuc2xhdGVYKDAuMjVyZW0pO1xufVxuLm9zYi1jdGEtLWFuaW1hdGUgPiBzdmcge1xuICB0cmFuc2l0aW9uOiB0cmFuc2Zvcm0gMC41cyBlYXNlO1xufVxuXG4ub3NiLWN0YS0tbGFyZ2Uge1xuICBmb250LXNpemU6IDEuNXJlbTtcbiAgbGluZS1oZWlnaHQ6IDM2cHg7XG59XG4ub3NiLWN0YS0tbGFyZ2UgLm9zYi1pY29uLS1jb250ZW50LWVkZ2Uub3NiLWljb24tLXNjYWxlIHtcbiAgbWFyZ2luLWxlZnQ6IC01cHg7XG4gIHBhZGRpbmc6IDExcHg7XG59XG5cbi5vc2ItY3RhLS1saWdodCxcbi5kYXJrIC5vc2ItY3RhIHtcbiAgY29sb3I6IHZhcigtLXdoaXRlKTtcbn1cbi5vc2ItY3RhLS1saWdodDp2aXNpdGVkLFxuLmRhcmsgLm9zYi1jdGE6dmlzaXRlZCB7XG4gIGNvbG9yOiB2YXIoLS13aGl0ZSk7XG59XG4ub3NiLWN0YS0tbGlnaHQ6aG92ZXIsXG4uZGFyayAub3NiLWN0YTpob3ZlciB7XG4gIGNvbG9yOiB2YXIoLS13aGl0ZSk7XG59XG4ub3NiLWN0YS0tbGlnaHQ6Zm9jdXMsIC5vc2ItY3RhLS1saWdodC5vc2ItYnRuLS1mb2N1cyxcbi5kYXJrIC5vc2ItY3RhOmZvY3VzLFxuLmRhcmsgLm9zYi1jdGEub3NiLWJ0bi0tZm9jdXMge1xuICBjb2xvcjogdmFyKC0td2hpdGUpO1xufVxuLm9zYi1jdGEtLWxpZ2h0OmFjdGl2ZSwgLm9zYi1jdGEtLWxpZ2h0Lm9zYi1idG4tLWFjdGl2ZSxcbi5kYXJrIC5vc2ItY3RhOmFjdGl2ZSxcbi5kYXJrIC5vc2ItY3RhLm9zYi1idG4tLWFjdGl2ZSB7XG4gIGNvbG9yOiB2YXIoLS13aGl0ZSk7XG59XG4ub3NiLWN0YS0tbGlnaHQ6ZGlzYWJsZWQsIC5vc2ItY3RhLS1saWdodC5vc2ItYnRuLS1kaXNhYmxlZCxcbi5kYXJrIC5vc2ItY3RhOmRpc2FibGVkLFxuLmRhcmsgLm9zYi1jdGEub3NiLWJ0bi0tZGlzYWJsZWQge1xuICBjb2xvcjogdmFyKC0td2hpdGUpO1xufVxuLm9zYi1idG4ge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgYm9yZGVyLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgYm9yZGVyLXN0eWxlOiBzb2xpZDtcbiAgYm9yZGVyLXdpZHRoOiAxcHg7XG4gIGJvcmRlci1yYWRpdXM6IDRweDtcbiAgYm94LXNoYWRvdzogMHB4IDAuOHB4IDMuN3B4IC0wLjMzcHggcmdiYSgwLCAwLCAwLCAwLjE0KSwgMHB4IDJweCAzcHggMC4xNXB4IHJnYmEoMCwgMCwgMCwgMC4wMzQpLCAwcHggMi42cHggNHB4IC0wLjJweCByZ2JhKDAsIDAsIDAsIDAuMDYpO1xuICBjb2xvcjogdmFyKC0tYmxhY2spO1xuICBjdXJzb3I6IHBvaW50ZXI7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgZm9udC1zaXplOiAxZW07XG4gIGZvbnQtd2VpZ2h0OiA2MDA7XG4gIGxpbmUtaGVpZ2h0OiAxO1xuICBtYXJnaW46IDAuMjVlbSAwIDAuMzc1ZW07XG4gIG1heC13aWR0aDogMTAwJTtcbiAgcGFkZGluZy1ib3R0b206IDAuNjg3NXJlbTtcbiAgcGFkZGluZy1sZWZ0OiAxcmVtO1xuICBwYWRkaW5nLXJpZ2h0OiAxcmVtO1xuICBwYWRkaW5nLXRvcDogMC42ODc1cmVtO1xuICB0ZXh0LWFsaWduOiBjZW50ZXI7XG4gIHRyYW5zaXRpb246IGFsbCAwLjJzIGVhc2UtaW4tb3V0O1xuICB1c2VyLXNlbGVjdDogbm9uZTtcbiAgdmVydGljYWwtYWxpZ246IG1pZGRsZTtcbiAgd29yZC13cmFwOiBicmVhay13b3JkO1xuICB6LWluZGV4OiAxO1xufVxuLm9zYi1idG46dmlzaXRlZCB7XG4gIGNvbG9yOiB2YXIoLS1ibGFjayk7XG59XG4ub3NiLWJ0bjpob3ZlciB7XG4gIGJveC1zaGFkb3c6IDBweCAxLjFweCA0LjA1cHggLTAuNjZweCByZ2JhKDAsIDAsIDAsIDAuMTQpLCAwcHggM3B4IDQuNXB4IDAuM3B4IHJnYmEoMCwgMCwgMCwgMC4wMzYpLCAwcHggMi45cHggNnB4IDAuMnB4IHJnYmEoMCwgMCwgMCwgMC4wNik7XG4gIGNvbG9yOiB2YXIoLS1ibGFjayk7XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKGNhbGMoLTNweCAtIDElKSk7XG4gIHRyYW5zaXRpb246IGFsbCAwLjJzO1xufVxuLm9zYi1idG46Zm9jdXMsIC5vc2ItYnRuLm9zYi1idG4tLWZvY3VzIHtcbiAgYm94LXNoYWRvdzogMCA1cHggMTFweCAtNXB4ICMwMDA7XG4gIGNvbG9yOiB2YXIoLS1ibGFjayk7XG4gIG91dGxpbmU6IDA7XG4gIHRyYW5zZm9ybTogdHJhbnNsYXRlWShjYWxjKC0zcHggLSAxJSkpO1xuICB0cmFuc2l0aW9uOiBhbGwgMC4ycztcbn1cbi5vc2ItYnRuOmFjdGl2ZSwgLm9zYi1idG4ub3NiLWJ0bi0tYWN0aXZlIHtcbiAgYm94LXNoYWRvdzogMCA1cHggOHB4IC01cHggcmdiYSgwLCAwLCAwLCAwLjUpO1xuICBjb2xvcjogdmFyKC0tYmxhY2spO1xuICB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoMCk7XG4gIHRyYW5zaXRpb246IGFsbCAwLjFzO1xufVxuLm9zYi1idG46ZGlzYWJsZWQsIC5vc2ItYnRuLm9zYi1idG4tLWRpc2FibGVkIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gIGJvcmRlci1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gIGJveC1zaGFkb3c6IDBweCAwLjhweCAzLjdweCAtMC4zM3B4IHJnYmEoMCwgMCwgMCwgMC4xNCksIDBweCAycHggM3B4IDAuMTVweCByZ2JhKDAsIDAsIDAsIDAuMDM0KSwgMHB4IDIuNnB4IDRweCAtMC4ycHggcmdiYSgwLCAwLCAwLCAwLjA2KTtcbiAgY29sb3I6IHZhcigtLWJsYWNrKTtcbiAgY3Vyc29yOiBub3QtYWxsb3dlZDtcbiAgb3BhY2l0eTogMC41O1xuICB0cmFuc2Zvcm06IG5vbmU7XG59XG4ub3NiLWJ0bjpkaXNhYmxlZDphY3RpdmUsIC5vc2ItYnRuLm9zYi1idG4tLWRpc2FibGVkOmFjdGl2ZSB7XG4gIHBvaW50ZXItZXZlbnRzOiBub25lO1xufVxuXG4ub3NiLWJ0bi0taWNvbi1zdGFydCB7XG4gIHBhZGRpbmctbGVmdDogMi41cmVtO1xuICBwb3NpdGlvbjogcmVsYXRpdmU7XG59XG4ub3NiLWJ0bi0taWNvbi1zdGFydCBzdmcge1xuICBoZWlnaHQ6IDEuNWVtO1xuICBsZWZ0OiAwLjY4NzVyZW07XG4gIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgdG9wOiA1MCU7XG4gIHRyYW5zZm9ybTogdHJhbnNsYXRlWSgtNDglKTtcbiAgd2lkdGg6IDEuNWVtO1xufVxuXG4ub3NiLWJ0bi0taWNvbi1lbmQge1xuICBwYWRkaW5nLXJpZ2h0OiAyLjVyZW07XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTtcbn1cbi5vc2ItYnRuLS1pY29uLWVuZCBzdmcge1xuICBoZWlnaHQ6IDEuNWVtO1xuICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gIHJpZ2h0OiAwLjY4NzVyZW07XG4gIHRvcDogNTAlO1xuICB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoLTQ4JSk7XG4gIHdpZHRoOiAxLjVlbTtcbn1cblxuLm9zYi1idG4tLWxhcmdlIHtcbiAgZm9udC1zaXplOiAxLjEyNWVtO1xuICBwYWRkaW5nLWJvdHRvbTogMC44NzVyZW07XG4gIHBhZGRpbmctbGVmdDogMS4xODc1cmVtO1xuICBwYWRkaW5nLXJpZ2h0OiAxLjE4NzVyZW07XG4gIHBhZGRpbmctdG9wOiAwLjg3NXJlbTtcbn1cbi5vc2ItYnRuLS1sYXJnZS5vc2ItYnRuLS1pY29uLXN0YXJ0IHtcbiAgcGFkZGluZy1sZWZ0OiAyLjc1cmVtO1xufVxuLm9zYi1idG4tLWxhcmdlLm9zYi1idG4tLWljb24tc3RhcnQgc3ZnIHtcbiAgbGVmdDogMC43NXJlbTtcbn1cbi5vc2ItYnRuLS1sYXJnZS5vc2ItYnRuLS1pY29uLWVuZCB7XG4gIHBhZGRpbmctcmlnaHQ6IDIuNzVyZW07XG59XG4ub3NiLWJ0bi0tbGFyZ2Uub3NiLWJ0bi0taWNvbi1lbmQgc3ZnIHtcbiAgcmlnaHQ6IDAuNzVyZW07XG59XG5cbi5vc2ItYnRuLS1zbWFsbCB7XG4gIGZvbnQtc2l6ZTogMC44NzVlbTtcbiAgbWFyZ2luOiAwLjVyZW0gYXV0bztcbiAgcGFkZGluZy1ib3R0b206IDAuNXJlbTtcbiAgcGFkZGluZy1sZWZ0OiAwLjVyZW07XG4gIHBhZGRpbmctcmlnaHQ6IDAuNXJlbTtcbiAgcGFkZGluZy10b3A6IDAuNXJlbTtcbn1cbkBtZWRpYSAobWluLXdpZHRoOiA5MDBweCkge1xuICAub3NiLWJ0bi0tc21hbGwge1xuICAgIG1hcmdpbjogMDtcbiAgfVxufVxuLm9zYi1idG4tLXNtYWxsLm9zYi1idG4tLWljb24tc3RhcnQge1xuICBwYWRkaW5nLWxlZnQ6IDEuNzVyZW07XG59XG4ub3NiLWJ0bi0tc21hbGwub3NiLWJ0bi0taWNvbi1zdGFydCBzdmcge1xuICBsZWZ0OiAwLjI1cmVtO1xufVxuLm9zYi1idG4tLXNtYWxsLm9zYi1idG4tLWljb24tZW5kIHtcbiAgcGFkZGluZy1yaWdodDogMS43NXJlbTtcbn1cbi5vc2ItYnRuLS1zbWFsbC5vc2ItYnRuLS1pY29uLWVuZCBzdmcge1xuICByaWdodDogMC4yNXJlbTtcbn1cblxuLm9zYi1idG4tLWJsb2NrIHtcbiAgZGlzcGxheTogYmxvY2s7XG4gIHdpZHRoOiAxMDAlO1xufVxuXG4ub3NiLWJ0bi0tbW9ub3NwYWNlZCB7XG4gIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gIGJveC1zaGFkb3c6IG5vbmU7XG4gIGRpc3BsYXk6IGlubGluZS1mbGV4O1xuICBoZWlnaHQ6IDIuNXJlbTtcbiAganVzdGlmeS1jb250ZW50OiBjZW50ZXI7XG4gIGxpbmUtaGVpZ2h0OiAxO1xuICBwYWRkaW5nOiAwO1xuICB0cmFuc2Zvcm06IG5vbmU7XG4gIHdpZHRoOiAyLjVyZW07XG59XG4ub3NiLWJ0bi0tbW9ub3NwYWNlZDpob3ZlciB7XG4gIGJveC1zaGFkb3c6IG5vbmU7XG4gIHRyYW5zZm9ybTogbm9uZTtcbn1cbi5vc2ItYnRuLS1tb25vc3BhY2VkOmZvY3VzLCAub3NiLWJ0bi0tbW9ub3NwYWNlZC5vc2ItYnRuLS1mb2N1cyB7XG4gIGJveC1zaGFkb3c6IG5vbmU7XG4gIHRyYW5zZm9ybTogbm9uZTtcbn1cbi5vc2ItYnRuLS1tb25vc3BhY2VkOmRpc2FibGVkLCAub3NiLWJ0bi0tbW9ub3NwYWNlZC5vc2ItYnRuLS1kaXNhYmxlZCB7XG4gIGJveC1zaGFkb3c6IG5vbmU7XG59XG4ub3NiLWJ0bi0tbW9ub3NwYWNlZC5vc2ItYnRuLS1sYXJnZSB7XG4gIGhlaWdodDogM3JlbTtcbiAgd2lkdGg6IDNyZW07XG59XG4ub3NiLWJ0bi0tbW9ub3NwYWNlZC5vc2ItYnRuLS1zbWFsbCB7XG4gIGhlaWdodDogMnJlbTtcbiAgd2lkdGg6IDJyZW07XG59XG4ub3NiLWJ0bi0tZmxhdCB7XG4gIG1hcmdpbi1ib3R0b206IDA7XG4gIG1hcmdpbi10b3A6IDA7XG4gIHRyYW5zaXRpb246IG5vbmU7XG59XG4ub3NiLWJ0bi0tZmxhdDpob3ZlciB7XG4gIHRyYW5zZm9ybTogbm9uZTtcbn1cbi5vc2ItYnRuLS1mbGF0OmZvY3VzLCAub3NiLWJ0bi0tZmxhdC5vc2ItYnRuLS1mb2N1cyB7XG4gIHRyYW5zZm9ybTogbm9uZTtcbn1cbi5vc2ItYnRuLS1mbGF0OmFjdGl2ZSwgLm9zYi1idG4tLWZsYXQub3NiLWJ0bi0tYWN0aXZlIHtcbiAgdHJhbnNmb3JtOiBub25lO1xuICB0cmFuc2l0aW9uOiBub25lO1xufVxuLm9zYi1idG4tLXByaW1hcnkge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdCk7XG4gIGJvcmRlci1jb2xvcjogdmFyKC0tYWN0aW9uLWRlZmF1bHQpO1xuICBjb2xvcjogdmFyKC0td2hpdGUpO1xufVxuLm9zYi1idG4tLXByaW1hcnk6dmlzaXRlZCB7XG4gIGNvbG9yOiB2YXIoLS13aGl0ZSk7XG59XG4ub3NiLWJ0bi0tcHJpbWFyeTpob3ZlciB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLWFjdGlvbi1kZWZhdWx0LWhvdmVyKTtcbiAgYm9yZGVyLWNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdC1ob3Zlcik7XG4gIGNvbG9yOiB2YXIoLS13aGl0ZSk7XG59XG4ub3NiLWJ0bi0tcHJpbWFyeTpmb2N1cywgLm9zYi1idG4tLXByaW1hcnkub3NiLWJ0bi0tZm9jdXMge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdC1ob3Zlcik7XG4gIGJvcmRlci1jb2xvcjogdmFyKC0tYWN0aW9uLWRlZmF1bHQtaG92ZXIpO1xuICBjb2xvcjogdmFyKC0td2hpdGUpO1xufVxuLm9zYi1idG4tLXByaW1hcnk6YWN0aXZlLCAub3NiLWJ0bi0tcHJpbWFyeS5vc2ItYnRuLS1hY3RpdmUge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdC1hY3RpdmUpO1xuICBib3JkZXItY29sb3I6IHZhcigtLWFjdGlvbi1kZWZhdWx0LWFjdGl2ZSk7XG4gIGNvbG9yOiB2YXIoLS13aGl0ZSk7XG59XG4ub3NiLWJ0bi0tcHJpbWFyeTpkaXNhYmxlZCwgLm9zYi1idG4tLXByaW1hcnkub3NiLWJ0bi0tZGlzYWJsZWQge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdCk7XG4gIGJvcmRlci1jb2xvcjogdmFyKC0tYWN0aW9uLWRlZmF1bHQpO1xuICBjb2xvcjogdmFyKC0td2hpdGUpO1xufVxuLm9zYi1idG4tLXNlY29uZGFyeSB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLXdoaXRlKTtcbiAgYm9yZGVyLWNvbG9yOiB2YXIoLS13aGl0ZSk7XG4gIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdCk7XG59XG4ub3NiLWJ0bi0tc2Vjb25kYXJ5OnZpc2l0ZWQge1xuICBjb2xvcjogdmFyKC0tYWN0aW9uLWRlZmF1bHQpO1xufVxuLm9zYi1idG4tLXNlY29uZGFyeTpob3ZlciB7XG4gIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdC1ob3Zlcik7XG59XG4ub3NiLWJ0bi0tc2Vjb25kYXJ5OmZvY3VzLCAub3NiLWJ0bi0tc2Vjb25kYXJ5Lm9zYi1idG4tLWZvY3VzIHtcbiAgY29sb3I6IHZhcigtLWFjdGlvbi1kZWZhdWx0LWhvdmVyKTtcbn1cbi5vc2ItYnRuLS1zZWNvbmRhcnk6YWN0aXZlLCAub3NiLWJ0bi0tc2Vjb25kYXJ5Lm9zYi1idG4tLWFjdGl2ZSB7XG4gIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdC1hY3RpdmUpO1xufVxuLm9zYi1idG4tLXNlY29uZGFyeTpkaXNhYmxlZCwgLm9zYi1idG4tLXNlY29uZGFyeS5vc2ItYnRuLS1kaXNhYmxlZCB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLXdoaXRlKTtcbiAgYm9yZGVyLWNvbG9yOiB2YXIoLS13aGl0ZSk7XG4gIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdCk7XG59XG4ub3NiLWJ0bi0tYWx0ZXJuYXRlIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tYWNjZW50LTYpO1xuICBib3JkZXItY29sb3I6IHZhcigtLWFjY2VudC02KTtcbiAgY29sb3I6IHZhcigtLXdoaXRlKTtcbn1cbi5vc2ItYnRuLS1hbHRlcm5hdGU6dmlzaXRlZCB7XG4gIGNvbG9yOiB2YXIoLS13aGl0ZSk7XG59XG4ub3NiLWJ0bi0tYWx0ZXJuYXRlOmhvdmVyIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogIzE2OTU0NTtcbiAgYm9yZGVyLWNvbG9yOiAjMTY5NTQ1O1xuICBjb2xvcjogdmFyKC0td2hpdGUpO1xufVxuLm9zYi1idG4tLWFsdGVybmF0ZTpmb2N1cywgLm9zYi1idG4tLWFsdGVybmF0ZS5vc2ItYnRuLS1mb2N1cyB7XG4gIGJhY2tncm91bmQtY29sb3I6ICMxNjk1NDU7XG4gIGJvcmRlci1jb2xvcjogIzE2OTU0NTtcbiAgY29sb3I6IHZhcigtLXdoaXRlKTtcbn1cbi5vc2ItYnRuLS1hbHRlcm5hdGU6YWN0aXZlLCAub3NiLWJ0bi0tYWx0ZXJuYXRlLm9zYi1idG4tLWFjdGl2ZSB7XG4gIGJhY2tncm91bmQtY29sb3I6ICMxMjdmM2E7XG4gIGJvcmRlci1jb2xvcjogIzEyN2YzYTtcbiAgY29sb3I6IHZhcigtLXdoaXRlKTtcbn1cbi5vc2ItYnRuLS1hbHRlcm5hdGU6ZGlzYWJsZWQsIC5vc2ItYnRuLS1hbHRlcm5hdGUub3NiLWJ0bi0tZGlzYWJsZWQge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1hY2NlbnQtNik7XG4gIGJvcmRlci1jb2xvcjogdmFyKC0tYWNjZW50LTYpO1xuICBjb2xvcjogdmFyKC0td2hpdGUpO1xufVxuLm9zYi1idG4tLXBsYWludGV4dCB7XG4gIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICBib3gtc2hhZG93OiBub25lO1xuICBjb2xvcjogdmFyKC0tYWN0aW9uLWRlZmF1bHQpO1xuICBjdXJzb3I6IGRlZmF1bHQ7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgZm9udC1zaXplOiAxLjEyNXJlbTtcbiAgZm9udC13ZWlnaHQ6IDYwMDtcbiAgbWF4LXdpZHRoOiAxMDAlO1xuICBwYWRkaW5nOiAwLjYyNXJlbSAwLjVyZW07XG4gIHdvcmQtd3JhcDogYnJlYWstd29yZDtcbn1cbi5vc2ItYnRuLS1wbGFpbnRleHQ6dmlzaXRlZCB7XG4gIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdCk7XG59XG4ub3NiLWJ0bi0tcGxhaW50ZXh0OmhvdmVyIHtcbiAgYm94LXNoYWRvdzogbm9uZTtcbiAgY29sb3I6IHZhcigtLWFjdGlvbi1kZWZhdWx0KTtcbn1cbi5vc2ItYnRuLS1wbGFpbnRleHQ6Zm9jdXMsIC5vc2ItYnRuLS1wbGFpbnRleHQub3NiLWJ0bi0tZm9jdXMge1xuICBib3gtc2hhZG93OiBub25lO1xuICBjb2xvcjogdmFyKC0tYWN0aW9uLWRlZmF1bHQpO1xufVxuLm9zYi1idG4tLXBsYWludGV4dDphY3RpdmUsIC5vc2ItYnRuLS1wbGFpbnRleHQub3NiLWJ0bi0tYWN0aXZlIHtcbiAgY29sb3I6IHZhcigtLWFjdGlvbi1kZWZhdWx0KTtcbn1cbi5vc2ItYnRuLS1wbGFpbnRleHQ6ZGlzYWJsZWQsIC5vc2ItYnRuLS1wbGFpbnRleHQub3NiLWJ0bi0tZGlzYWJsZWQge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgYm94LXNoYWRvdzogbm9uZTtcbiAgY29sb3I6IHZhcigtLWFjdGlvbi1kZWZhdWx0KTtcbn1cbi5vc2ItYnRuLS1wbGFpbnRleHQub3NiLWJ0bi0taWNvbi1zdGFydCB7XG4gIHBhZGRpbmctbGVmdDogMnJlbTtcbn1cbi5vc2ItYnRuLS1wbGFpbnRleHQub3NiLWJ0bi0taWNvbi1zdGFydCA+IHN2ZyB7XG4gIGxlZnQ6IDNweDtcbiAgbWFyZ2luLXRvcDogMDtcbn1cbi5vc2ItYnRuLS1wbGFpbnRleHQub3NiLWJ0bi0taWNvbi1lbmQge1xuICBwYWRkaW5nLXJpZ2h0OiAycmVtO1xufVxuLm9zYi1idG4tLXBsYWludGV4dC5vc2ItYnRuLS1pY29uLWVuZCA+IHN2ZyB7XG4gIG1hcmdpbi10b3A6IDA7XG4gIHJpZ2h0OiAzcHg7XG59XG4ub3NiLWJ0bi0tcGxhaW50ZXh0Lm9zYi1idG4tLXNtYWxsIHtcbiAgcGFkZGluZy1ib3R0b206IDAuMzc1cmVtO1xuICBwYWRkaW5nLXRvcDogMC4zNzVyZW07XG59XG4ub3NiLWJ0bi0tcGxhaW50ZXh0Lm9zYi1idG4tLWxhcmdlIHtcbiAgZm9udC1zaXplOiAxLjVyZW07XG4gIGxpbmUtaGVpZ2h0OiAzNnB4O1xuICBwYWRkaW5nLWJvdHRvbTogMC4zNDM3NXJlbTtcbiAgcGFkZGluZy10b3A6IDAuMzQzNzVyZW07XG59XG4ub3NiLWJ0bi0tcGxhaW50ZXh0Lm9zYi1idG4tLWxhcmdlLm9zYi1idG4tLWljb24tc3RhcnQge1xuICBwYWRkaW5nLWxlZnQ6IDIuNXJlbTtcbn1cbi5vc2ItYnRuLS1wbGFpbnRleHQub3NiLWJ0bi0tbGFyZ2Uub3NiLWJ0bi0taWNvbi1zdGFydCA+IHN2ZyB7XG4gIGxlZnQ6IDFweDtcbn1cbi5vc2ItYnRuLS1wbGFpbnRleHQub3NiLWJ0bi0tbGFyZ2Uub3NiLWJ0bi0taWNvbi1lbmQge1xuICBwYWRkaW5nLXJpZ2h0OiAyLjVyZW07XG59XG4ub3NiLWJ0bi0tcGxhaW50ZXh0Lm9zYi1idG4tLWxhcmdlLm9zYi1idG4tLWljb24tZW5kID4gc3ZnIHtcbiAgcmlnaHQ6IDFweDtcbn1cblxuLm9zYi1jYXJkIHtcbiAgYm94LXNoYWRvdzogMHB4IDAuOHB4IDMuN3B4IC0wLjMzcHggcmdiYSgwLCAwLCAwLCAwLjE0KSwgMHB4IDJweCAzcHggMC4xNXB4IHJnYmEoMCwgMCwgMCwgMC4wMzQpLCAwcHggMi42cHggNHB4IC0wLjJweCByZ2JhKDAsIDAsIDAsIDAuMDYpO1xuICBjdXJzb3I6IHBvaW50ZXI7XG4gIGNvbG9yOiB2YXIoLS1ibGFjayk7XG4gIG1hcmdpbi1ib3R0b206IDA7XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgdHJhbnNpdGlvbjogYWxsIDAuMnMgZWFzZS1pbi1vdXQ7XG59XG4ub3NiLWNhcmQ6aG92ZXIge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS13aGl0ZSk7XG4gIGJveC1zaGFkb3c6IDBweCAxLjFweCA0LjA1cHggLTAuNjZweCByZ2JhKDAsIDAsIDAsIDAuMTQpLCAwcHggM3B4IDQuNXB4IDAuM3B4IHJnYmEoMCwgMCwgMCwgMC4wMzYpLCAwcHggMi45cHggNnB4IDAuMnB4IHJnYmEoMCwgMCwgMCwgMC4wNik7XG4gIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdC1ob3Zlcik7XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKGNhbGMoLTNweCAtIDElKSk7XG4gIHRyYW5zaXRpb246IGFsbCAwLjJzO1xufVxuXG5ib2R5Lm1vYmlsZS10YWJsZXQtbmF2LXZpc2libGUge1xuICBvdmVyZmxvdzogaGlkZGVuO1xufVxuXG5AbWVkaWEgKG1pbi13aWR0aDogMTIwMHB4KSB7XG4gIGJvZHkubmF2LWRyb3Bkb3duLW1lbnUtb3ZlcmZsb3cge1xuICAgIG92ZXJmbG93OiBoaWRkZW47XG4gIH1cbiAgYm9keS5uYXYtZHJvcGRvd24tbWVudS1vdmVyZmxvdy5oYXMtYWxlcnQtY29udGFpbmVyIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudSAuYWR0LXN1Ym1lbnUtb3V0ZXItd3JhcHBlciAuYWR0LXN1Ym1lbnUtaW5uZXItd3JhcHBlciB7XG4gICAgbWFyZ2luLWJvdHRvbTogNHJlbTtcbiAgfVxuICBib2R5Lm5hdi1kcm9wZG93bi1tZW51LW92ZXJmbG93IC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudSAuYWR0LXN1Ym1lbnUtb3V0ZXItd3JhcHBlciAuYWR0LXN1Ym1lbnUtaW5uZXItd3JhcHBlciB7XG4gICAgbWFyZ2luLWJvdHRvbTogM3JlbTtcbiAgfVxufVxuLmhhcy1hbGVydC1jb250YWluZXIuZmlsbC1iYW5uZXIgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIHtcbiAgcG9zaXRpb246IGZpeGVkO1xufVxuLmhhcy1hbGVydC1jb250YWluZXIgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIHtcbiAgcG9zaXRpb246IGFic29sdXRlO1xuICB0b3A6IDQ4cHg7XG59XG5cbi5maWxsLWJhbm5lciAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIge1xuICBib3gtc2hhZG93OiAwcHggNy40cHggMTEuNHB4IC03LjU5cHggcmdiYSgwLCAwLCAwLCAwLjE0KSwgMHB4IDI0cHggMzZweCAzLjQ1cHggcmdiYSgwLCAwLCAwLCAwLjA3OCksIDBweCA5LjJweCA0OHB4IDguNnB4IHJnYmEoMCwgMCwgMCwgMC4wNik7XG4gIHRvcDogMDtcbn1cblxuLmhhcy1jb250cm9sLW1lbnUgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIHtcbiAgdG9wOiA1NnB4O1xufVxuQG1lZGlhIChtYXgtd2lkdGg6IDU3NnB4KSB7XG4gIC5oYXMtY29udHJvbC1tZW51IC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciB7XG4gICAgdG9wOiA0OHB4O1xuICB9XG59XG4uaGFzLWNvbnRyb2wtbWVudS5oYXMtYWxlcnQtY29udGFpbmVyLmZpbGwtYmFubmVyIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciB7XG4gIHRvcDogNTZweDtcbn1cbi5oYXMtY29udHJvbC1tZW51Lmhhcy1hbGVydC1jb250YWluZXIgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIHtcbiAgdG9wOiA0OHB4O1xufVxuLmhhcy1jb250cm9sLW1lbnUuaGFzLWVkaXQtbW9kZS1tZW51Lmhhcy1hbGVydC1jb250YWluZXIuZmlsbC1iYW5uZXIgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyLFxuLmhhcy1jb250cm9sLW1lbnUuaGFzLWVkaXQtbW9kZS1tZW51Lmhhcy1hbGVydC1jb250YWluZXIgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyLFxuLmhhcy1jb250cm9sLW1lbnUuaGFzLWVkaXQtbW9kZS1tZW51Lmhhcy1hbGVydC1jb250YWluZXIgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5zZWFyY2gtd3JhcHBlci5zZWFyY2gtb3BlbiB7XG4gIHBvc2l0aW9uOiBmaXhlZDtcbiAgdG9wOiBjYWxjKDU2cHggKyA2NXB4KTtcbn1cbi5oYXMtY29udHJvbC1tZW51Lmhhcy1lZGl0LW1vZGUtbWVudSAuZi1uYXZpZ2F0aW9uLXByaW1hcnkge1xuICB0b3A6IGNhbGMoNTZweCArIDY1cHgpO1xufVxuXG4ucHJvZHVjdC1tZW51LW9wZW4gLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIHtcbiAgbGVmdDogMzIwcHg7XG59XG5cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS1wYWRkaW5nIHtcbiAgcGFkZGluZy10b3A6IDY0cHg7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnktcGFkZGluZy51dGlsaXR5LW5hdmlnYXRpb24tcGFkZGluZyB7XG4gIHBhZGRpbmctdG9wOiAxMTJweDtcbn1cbkBtZWRpYSAobWF4LXdpZHRoOiA1OTlweCkge1xuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnktcGFkZGluZy51dGlsaXR5LW5hdmlnYXRpb24tcGFkZGluZyB7XG4gICAgcGFkZGluZy10b3A6IDY0cHg7XG4gIH1cbn1cblxuQG1lZGlhIChtaW4td2lkdGg6IDEyMDBweCkge1xuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkuZGFyay10aGVtZS5uYXYtd3JhcHBlciAubmF2IHtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1wcmltYXJ5LWRhcmspO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5kYXJrLXRoZW1lLm5hdi13cmFwcGVyIC5uYXYgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLm5hdi1pdGVtcy13cmFwcGVyLFxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkuZGFyay10aGVtZS5uYXYtd3JhcHBlciAubmF2IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5saWZlcmF5LWxvZ286aG92ZXIge1xuICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5kYXJrLXRoZW1lLm5hdi13cmFwcGVyIC5uYXYgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLm5hdi1pdGVtcy13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1uYXYtdGV4dDo6YWZ0ZXIge1xuICAgIGJhY2tncm91bmQ6IHZhcigtLXdoaXRlKTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkuZGFyay10aGVtZS5uYXYtd3JhcHBlciAuYWR0LW5hdi10ZXh0IHtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICBjb2xvcjogd2hpdGU7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5LmRhcmstdGhlbWUubmF2LXdyYXBwZXIgLmFkdC1uYXYtdGV4dDpob3ZlciwgLmYtbmF2aWdhdGlvbi1wcmltYXJ5LmRhcmstdGhlbWUubmF2LXdyYXBwZXIgLmFkdC1uYXYtdGV4dDpmb2N1cyB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0td2hpdGUpO1xuICB9XG59XG5AbWVkaWEgKG1pbi13aWR0aDogNjAwcHgpIGFuZCAobWF4LXdpZHRoOiAxMTk5cHgpIHtcbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5LmRhcmstdGhlbWUubmF2LXdyYXBwZXIgLm1vYmlsZS1idXR0b25zIC5tb2JpbGUtbWVudSB7XG4gICAgYm9yZGVyLWNvbG9yOiB2YXIoLS13aGl0ZSk7XG4gICAgY29sb3I6IHZhcigtLXdoaXRlKTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkuZGFyay10aGVtZS5uYXYtd3JhcHBlciAucHJpbWFyeS1uYXYge1xuICAgIGJhY2tncm91bmQtY29sb3I6IHZhcigtLXByaW1hcnktZGFyayk7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5LmRhcmstdGhlbWUubmF2LXdyYXBwZXIgLnV0aWxpdHktbmF2IHtcbiAgICBkaXNwbGF5OiBub25lO1xuICB9XG59XG5AbWVkaWEgKG1heC13aWR0aDogNTk5cHgpIHtcbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5LmRhcmstdGhlbWUubmF2LXdyYXBwZXIgLnV0aWxpdHktbmF2IHtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1wcmltYXJ5LWRhcmspO1xuICAgIGJvcmRlci1ib3R0b20tY29sb3I6IHRyYW5zcGFyZW50O1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5kYXJrLXRoZW1lLm5hdi13cmFwcGVyIC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC51dGlsaXR5LW5hdi1yaWdodCAuc2VhcmNoLWJ1dHRvbiB7XG4gICAgZGlzcGxheTogbm9uZTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkuZGFyay10aGVtZS5uYXYtd3JhcHBlciAudXRpbGl0eS1uYXYgLmNvbnRlbnQtd3JhcHBlciAuZHJvcGRvd24gLnV0aWxpdHktbmF2LWxpbmsubGFuZ3VhZ2Utc2VsZWN0b3Ige1xuICAgIGNvbG9yOiB2YXIoLS13aGl0ZSk7XG4gICAgb3BhY2l0eTogMTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkuZGFyay10aGVtZS5uYXYtd3JhcHBlciAudXRpbGl0eS1uYXYgLmNvbnRlbnQtd3JhcHBlciAuZHJvcGRvd24gLnV0aWxpdHktbmF2LWxpbmsubGFuZ3VhZ2Utc2VsZWN0b3Igc3ZnIHtcbiAgICBmaWxsOiB2YXIoLS13aGl0ZSk7XG4gIH1cbn1cblxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIHtcbiAgYm90dG9tOiBhdXRvO1xuICBsZWZ0OiAwO1xuICBwb3NpdGlvbjogZml4ZWQ7XG4gIHJpZ2h0OiAwO1xuICB0b3A6IDA7XG4gIHRyYW5zaXRpb246IGJveC1zaGFkb3cgMC4zcyBlYXNlO1xuICB3aWxsLWNoYW5nZTogYm94LXNoYWRvdztcbiAgei1pbmRleDogOTgwO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyLnNlYXJjaC1vcGVuIHtcbiAgei1pbmRleDogOTgyO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5uYXYge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS13aGl0ZSk7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgKiB7XG4gIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLnV0aWxpdHktbmF2IC5saWZlcmF5LWxvZ28ge1xuICBkaXNwbGF5OiBub25lO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2aWdhdGlvbiB7XG4gIGRpc3BsYXk6IGZsZXg7XG4gIGZsZXgtd3JhcDogaW5oZXJpdDtcbiAgbGlzdC1zdHlsZTogbm9uZTtcbiAgbWFyZ2luLWJvdHRvbTogMDtcbiAgcGFkZGluZy1sZWZ0OiAwO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0ge1xuICBvdXRsaW5lOiAwcHggc29saWQgdHJhbnNwYXJlbnQ7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbTpmb2N1cyAuYWR0LW5hdi10ZXh0IHtcbiAgYmFja2dyb3VuZC1jb2xvcjogI2ViZjJmZjtcbiAgY29sb3I6IHZhcigtLWFjdGlvbi1kZWZhdWx0LWhvdmVyKTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtbmF2LXRleHQ6Zm9jdXMge1xuICBvdXRsaW5lOiBub25lO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0uZHJvcGRvd24tb3BlbiAuYWR0LWFuZ2xlLWRvd24tc3ZnIHtcbiAgdHJhbnNmb3JtOiB0cmFuc2xhdGUzZCgwcHgsIDBweCwgMHB4KSBzY2FsZTNkKDEsIDEsIDEpIHJvdGF0ZVgoMTgwZGVnKSByb3RhdGVZKDBkZWcpIHJvdGF0ZVooMGRlZykgc2tldygwZGVnLCAwZGVnKTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtLmRyb3Bkb3duLW9wZW4gLmFkdC1uYXYtdGV4dCB7XG4gIGJhY2tncm91bmQtY29sb3I6ICNlYmYyZmY7XG4gIGJvcmRlci1yYWRpdXM6IDRweDtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtLmRyb3Bkb3duLW9wZW4gLmFkdC1uYXYtdGV4dCAuYWR0LW5hdi10aXRsZSB7XG4gIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdC1hY3RpdmUpO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0uZHJvcGRvd24tb3BlbiAuYWR0LXN1Ym1lbnUge1xuICBtYXJnaW46IDA7XG4gIG9wYWNpdHk6IDE7XG4gIHRyYW5zZm9ybTogdHJhbnNsYXRlWSgwKTtcbiAgdmlzaWJpbGl0eTogdmlzaWJsZTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudSB7XG4gIGJhY2tncm91bmQtY2xpcDogcGFkZGluZy1ib3g7XG4gIGJhY2tncm91bmQtY29sb3I6ICNmZmY7XG4gIGJvcmRlci1jb2xvcjogI2U3ZTdlZDtcbiAgYm9yZGVyLXN0eWxlOiBzb2xpZDtcbiAgYm9yZGVyLXdpZHRoOiAwO1xuICBkaXNwbGF5OiBibG9jaztcbiAgZmxvYXQ6IGxlZnQ7XG4gIGxlZnQ6IDA7XG4gIGxpc3Qtc3R5bGU6IG5vbmU7XG4gIG1hcmdpbjogMC4zMTI1cmVtIDAgMDtcbiAgbWF4LWhlaWdodDogODB2aDtcbiAgbWF4LXdpZHRoOiBub25lO1xuICBtaW4taGVpZ2h0OiBhdXRvO1xuICBvcGFjaXR5OiAwO1xuICBvdmVyZmxvdzogYXV0bztcbiAgcGFkZGluZzogMXJlbSA0cmVtIDQuNXJlbSA0cmVtO1xuICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gIHJpZ2h0OiAwO1xuICB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoLTEwMHB4KTtcbiAgdHJhbnNpdGlvbjogdHJhbnNmb3JtIDAuM3MgY3ViaWMtYmV6aWVyKDAuMjMsIDEsIDAuMzIsIDEpLCBvcGFjaXR5IDAuMXMgbGluZWFyLCB2aXNpYmlsaXR5IDAuM3MgbGluZWFyO1xuICB2aXNpYmlsaXR5OiBoaWRkZW47XG4gIHotaW5kZXg6IC0xO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51IC5hZHQtc3VibWVudS1vdXRlci13cmFwcGVyIHtcbiAgd2lkdGg6IDEwMCU7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUgLmFkdC1zdWJtZW51LW91dGVyLXdyYXBwZXIgLmFkdC1zdWJtZW51LWlubmVyLXdyYXBwZXIge1xuICBkaXNwbGF5OiBncmlkO1xuICBncmlkLWNvbHVtbi1nYXA6IDRyZW07XG4gIGdyaWQtcm93LWdhcDogMi41cmVtO1xuICBncmlkLXRlbXBsYXRlLWNvbHVtbnM6IHJlcGVhdCgxMiwgMWZyKTtcbiAgbWFyZ2luOiAwIGF1dG87XG4gIG1heC13aWR0aDogMTI0MHB4O1xuICB3aWR0aDogMTAwJTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1oZWFkZXIge1xuICBib3JkZXItYm90dG9tOiAxcHggc29saWQgdmFyKC0tbmV1dHJhbC03KTtcbiAgLW1zLWdyaWQtcm93OiBzcGFuIDE7XG4gIGdyaWQtcm93LWVuZDogc3BhbiAxO1xuICAtbXMtZ3JpZC1yb3ctc3BhbjogMTtcbiAgZ3JpZC1yb3ctc3RhcnQ6IHNwYW4gMTtcbiAgbGlzdC1zdHlsZTogbm9uZTtcbiAgbWFyZ2luLWJvdHRvbTogLTFyZW07XG4gIHBhZGRpbmctYm90dG9tOiAwLjVyZW07XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50IHtcbiAgZGlzcGxheTogZmxleDtcbiAgbGlzdC1zdHlsZTogbm9uZTtcbiAgbWF4LXdpZHRoOiAyNzRweDtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1pdGVtLWNvbnRlbnQuaW1hZ2UtdHlwZSB7XG4gIG1heC13aWR0aDogbm9uZTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1pdGVtLWNvbnRlbnQgLmFkdC1zdWJtZW51LWl0ZW0tbGluayB7XG4gIGRpc3BsYXk6IGZsZXg7XG4gIHRyYW5zaXRpb246IGJveC1zaGFkb3cgMC4xcyBsaW5lYXIsIGJhY2tncm91bmQtY29sb3IgMC4xcyBsaW5lYXI7XG4gIHVzZXItc2VsZWN0OiBub25lO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LWl0ZW0tY29udGVudCAuYWR0LXN1Ym1lbnUtaXRlbS1saW5rOmhvdmVyLCAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50IC5hZHQtc3VibWVudS1pdGVtLWxpbms6Zm9jdXMge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjZWJmMmZmO1xuICBib3JkZXItcmFkaXVzOiAwLjVweDtcbiAgYm94LXNoYWRvdzogMCAwIDAgOHB4ICNlYmYyZmY7XG4gIG91dGxpbmU6IG5vbmU7XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1pdGVtLWNvbnRlbnQgLmFkdC1zdWJtZW51LWl0ZW0tbGluazpob3ZlciAuYWR0LXN1Ym1lbnUtaXRlbS10aXRsZSwgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LWl0ZW0tY29udGVudCAuYWR0LXN1Ym1lbnUtaXRlbS1saW5rOmZvY3VzIC5hZHQtc3VibWVudS1pdGVtLXRpdGxlIHtcbiAgY29sb3I6IHZhcigtLWFjdGlvbi1kZWZhdWx0LWhvdmVyKTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1pdGVtLWNvbnRlbnQgLmFkdC1zdWJtZW51LWl0ZW0tbGluayAuYWR0LXN1Ym1lbnUtaXRlbS10aXRsZSB7XG4gIHBhZGRpbmctYm90dG9tOiAwLjVyZW07XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtaXRlbS1pbWFnZSB7XG4gIGJvcmRlci1yYWRpdXM6IDRweDtcbiAgaGVpZ2h0OiA5NHB4O1xuICBtYXJnaW4tcmlnaHQ6IDFyZW07XG4gIG9iamVjdC1maXQ6IGNvdmVyO1xuICB3aWR0aDogOTRweDtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1pdGVtLXByZWhlYWRlciB7XG4gIGZvbnQtc2l6ZTogMC45cmVtO1xuICBsZXR0ZXItc3BhY2luZzogMC4xZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjI1cmVtO1xuICBwYWRkaW5nLWJvdHRvbTogMC41cmVtO1xuICB0ZXh0LXRyYW5zZm9ybTogdXBwZXJjYXNlO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24ge1xuICAtd2Via2l0LWFsaWduLWl0ZW1zOiBzdGFydDtcbiAgYWxpZ24taXRlbXM6IHN0YXJ0O1xuICAtd2Via2l0LWJveC1hbGlnbjogc3RhcnQ7XG4gIGRpc3BsYXk6IC1tcy1ncmlkO1xuICBkaXNwbGF5OiBncmlkO1xuICAtbXMtZmxleC1hbGlnbjogc3RhcnQ7XG4gIGdyaWQtYXV0by1jb2x1bW5zOiAxZnI7XG4gIGdyaWQtYXV0by1yb3dzOiBtaW4tY29udGVudDtcbiAgZ3JpZC1jb2x1bW4tZ2FwOiA0cmVtO1xuICBncmlkLXJvdy1nYXA6IDIuNXJlbTtcbiAgbGlzdC1zdHlsZTogbm9uZTtcbiAgcGFkZGluZzogMnJlbSAwO1xuICB3aWR0aDogMTAwJTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLmxpZ2h0LWJsdWUge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1wcmltYXJ5LTUpO1xuICBib3JkZXItcmFkaXVzOiA4cHg7XG4gIHBhZGRpbmc6IDJyZW07XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fMy1zZWN0aW9uLXNwYW4ge1xuICAtbXMtZ3JpZC1jb2x1bW4tc3BhbjogMztcbiAgZ3JpZC1jb2x1bW4tc3RhcnQ6IHNwYW4gMztcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLl8zLXNlY3Rpb24tc3BhbiAuYWR0LXN1Ym1lbnUtaGVhZGVyIHtcbiAgLW1zLWdyaWQtY29sdW1uLXNwYW46IDM7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDM7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fNC1zZWN0aW9uLXNwYW4ge1xuICAtbXMtZ3JpZC1jb2x1bW4tc3BhbjogNDtcbiAgZ3JpZC1jb2x1bW4tc3RhcnQ6IHNwYW4gNDtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLl80LXNlY3Rpb24tc3BhbiAuYWR0LXN1Ym1lbnUtaGVhZGVyIHtcbiAgLW1zLWdyaWQtY29sdW1uLXNwYW46IDQ7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDQ7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fNS1zZWN0aW9uLXNwYW4ge1xuICAtbXMtZ3JpZC1jb2x1bW4tc3BhbjogNTtcbiAgZ3JpZC1jb2x1bW4tc3RhcnQ6IHNwYW4gNTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLl81LXNlY3Rpb24tc3BhbiAuYWR0LXN1Ym1lbnUtaGVhZGVyIHtcbiAgLW1zLWdyaWQtY29sdW1uOiAyL3NwYW4gNTtcbiAgLW1zLWdyaWQtY29sdW1uLXNwYW46IDU7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDU7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fNi1zZWN0aW9uLXNwYW4ge1xuICAtbXMtZ3JpZC1jb2x1bW4tc3BhbjogNjtcbiAgZ3JpZC1jb2x1bW4tc3RhcnQ6IHNwYW4gNjtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLl82LXNlY3Rpb24tc3BhbiAuYWR0LXN1Ym1lbnUtaGVhZGVyIHtcbiAgLW1zLWdyaWQtY29sdW1uOiAyL3NwYW4gNjtcbiAgLW1zLWdyaWQtY29sdW1uLXNwYW46IDY7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDY7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fNy1zZWN0aW9uLXNwYW4ge1xuICAtbXMtZ3JpZC1jb2x1bW4tc3BhbjogNztcbiAgZ3JpZC1jb2x1bW4tc3RhcnQ6IHNwYW4gNztcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLl83LXNlY3Rpb24tc3BhbiAuYWR0LXN1Ym1lbnUtaGVhZGVyIHtcbiAgLW1zLWdyaWQtY29sdW1uOiAyL3NwYW4gNztcbiAgLW1zLWdyaWQtY29sdW1uLXNwYW46IDc7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDc7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fOC1zZWN0aW9uLXNwYW4ge1xuICAtbXMtZ3JpZC1jb2x1bW4tc3BhbjogODtcbiAgZ3JpZC1jb2x1bW4tc3RhcnQ6IHNwYW4gODtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLl84LXNlY3Rpb24tc3BhbiAuYWR0LXN1Ym1lbnUtaGVhZGVyIHtcbiAgLW1zLWdyaWQtY29sdW1uOiAyL3NwYW4gODtcbiAgLW1zLWdyaWQtY29sdW1uLXNwYW46IDg7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDg7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fOS1zZWN0aW9uLXNwYW4ge1xuICAtbXMtZ3JpZC1jb2x1bW4tc3BhbjogOTtcbiAgZ3JpZC1jb2x1bW4tc3RhcnQ6IHNwYW4gOTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLl85LXNlY3Rpb24tc3BhbiAuYWR0LXN1Ym1lbnUtaGVhZGVyIHtcbiAgLW1zLWdyaWQtY29sdW1uOiAyL3NwYW4gOTtcbiAgLW1zLWdyaWQtY29sdW1uLXNwYW46IDk7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDk7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fMTAtc2VjdGlvbi1zcGFuIHtcbiAgLW1zLWdyaWQtY29sdW1uLXNwYW46IDEwO1xuICBncmlkLWNvbHVtbi1zdGFydDogc3BhbiAxMDtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLl8xMC1zZWN0aW9uLXNwYW4gLmFkdC1zdWJtZW51LWhlYWRlciB7XG4gIC1tcy1ncmlkLWNvbHVtbjogMi9zcGFuIDEwO1xuICAtbXMtZ3JpZC1jb2x1bW4tc3BhbjogMTA7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDEwO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24uXzExLXNlY3Rpb24tc3BhbiB7XG4gIC1tcy1ncmlkLWNvbHVtbi1zcGFuOiAxMTtcbiAgZ3JpZC1jb2x1bW4tc3RhcnQ6IHNwYW4gMTE7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fMTEtc2VjdGlvbi1zcGFuIC5hZHQtc3VibWVudS1oZWFkZXIge1xuICAtbXMtZ3JpZC1jb2x1bW46IDIvc3BhbiAxMTtcbiAgLW1zLWdyaWQtY29sdW1uLXNwYW46IDExO1xuICBncmlkLWNvbHVtbi1zdGFydDogc3BhbiAxMTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLl8xMi1zZWN0aW9uLXNwYW4ge1xuICAtbXMtZ3JpZC1jb2x1bW4tc3BhbjogMTI7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDEyO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24uXzEyLXNlY3Rpb24tc3BhbiAuYWR0LXN1Ym1lbnUtaGVhZGVyIHtcbiAgLW1zLWdyaWQtY29sdW1uOiAyL3NwYW4gMTI7XG4gIC1tcy1ncmlkLWNvbHVtbi1zcGFuOiAxMjtcbiAgZ3JpZC1jb2x1bW4tc3RhcnQ6IHNwYW4gMTI7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbiAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50LmdyaWQtY29sdW1uLXNwYW4tMSB7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDE7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbiAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50LmdyaWQtY29sdW1uLXNwYW4tMiB7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDI7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbiAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50LmdyaWQtY29sdW1uLXNwYW4tMyB7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDM7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbiAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50LmdyaWQtY29sdW1uLXNwYW4tNCB7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDQ7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbiAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50LmdyaWQtY29sdW1uLXNwYW4tNSB7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDU7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbiAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50LmdyaWQtY29sdW1uLXNwYW4tNiB7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDY7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbiAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50LmdyaWQtY29sdW1uLXNwYW4tNyB7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDc7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbiAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50LmdyaWQtY29sdW1uLXNwYW4tOCB7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDg7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbiAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50LmdyaWQtY29sdW1uLXNwYW4tOSB7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDk7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbiAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50LmdyaWQtY29sdW1uLXNwYW4tMTAge1xuICBncmlkLWNvbHVtbi1zdGFydDogc3BhbiAxMDtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uIC5hZHQtc3VibWVudS1pdGVtLWNvbnRlbnQuZ3JpZC1jb2x1bW4tc3Bhbi0xMSB7XG4gIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDExO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24gLmFkdC1zdWJtZW51LWl0ZW0tY29udGVudC5ncmlkLWNvbHVtbi1zcGFuLTEyIHtcbiAgZ3JpZC1jb2x1bW4tc3RhcnQ6IHNwYW4gMTI7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtdGV4dCB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLXdoaXRlKTtcbiAgY29sb3I6IHZhcigtLW5ldXRyYWwtMik7XG4gIGZvbnQtd2VpZ2h0OiA2MDA7XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xuICB0cmFuc2l0aW9uLWR1cmF0aW9uOiAwLjJzLCAwLjJzO1xuICB0cmFuc2l0aW9uLXByb3BlcnR5OiBjb2xvciwgYmFja2dyb3VuZC1jb2xvcjtcbiAgdHJhbnNpdGlvbi10aW1pbmctZnVuY3Rpb246IGVhc2UsIGVhc2U7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtdGV4dDpob3ZlciwgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LXRleHQ6Zm9jdXMge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjZWJmMmZmO1xuICBjb2xvcjogdmFyKC0tYWN0aW9uLWRlZmF1bHQtaG92ZXIpO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAuYWR0LW5hdi1pdGVtLFxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAucG9ydGxldCB7XG4gIHBvc2l0aW9uOiBzdGF0aWM7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLnNlYXJjaC13cmFwcGVyLnNlYXJjaC1vcGVuIHtcbiAgbWluLWhlaWdodDogODB2aDtcbiAgb3BhY2l0eTogMTtcbiAgdHJhbnNmb3JtOiB0cmFuc2xhdGUzZCgwcHgsIDBweCwgMHB4KTtcbiAgei1pbmRleDogMjtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2VhcmNoLXdyYXBwZXIge1xuICBhbGlnbi1pdGVtczogY2VudGVyO1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1hY2NlbnQtMTApO1xuICBib3JkZXItcmFkaXVzOiAwIDAgOHB4IDhweDtcbiAgYm90dG9tOiBhdXRvO1xuICBib3gtc2hhZG93OiAwcHggMS4xcHggNC4wNXB4IC0wLjY2cHggcmdiYSgwLCAwLCAwLCAwLjE0KSwgMHB4IDNweCA0LjVweCAwLjNweCByZ2JhKDAsIDAsIDAsIDAuMDM2KSwgMHB4IDIuOXB4IDZweCAwLjJweCByZ2JhKDAsIDAsIDAsIDAuMDYpO1xuICBkaXNwbGF5OiBmbGV4O1xuICBmbGV4LWRpcmVjdGlvbjogY29sdW1uO1xuICBsZWZ0OiAwO1xuICBvcGFjaXR5OiAwO1xuICBwYWRkaW5nOiAzLjVyZW07XG4gIHBvc2l0aW9uOiBmaXhlZDtcbiAgcmlnaHQ6IDA7XG4gIHRvcDogMDtcbiAgdHJhbnNmb3JtOiB0cmFuc2xhdGUzZCgwcHgsIC04MDBweCwgMHB4KTtcbiAgdHJhbnNmb3JtLXN0eWxlOiBwcmVzZXJ2ZS0zZDtcbiAgdHJhbnNpdGlvbjogdHJhbnNmb3JtIDAuMjVzLCBvcGFjaXR5IDAuMjVzO1xuICB6LWluZGV4OiAtMjtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2VhcmNoLXdyYXBwZXIgZm9ybS5zZWFyY2gge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiByZ2JhKDI1NSwgMjU1LCAyNTUsIDAuMDUpO1xuICBib3JkZXItcmFkaXVzOiA0cHg7XG4gIG1hcmdpbi1ib3R0b206IDA7XG4gIG1hcmdpbi1sZWZ0OiBhdXRvO1xuICBtYXJnaW4tcmlnaHQ6IGF1dG87XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgd2lkdGg6IDMwcmVtO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5zZWFyY2gtd3JhcHBlciBmb3JtLnNlYXJjaCBpbnB1dC5zZWFyY2gtaW5wdXQge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgYm9yZGVyOiAwIG5vbmUgIzAwMDtcbiAgY29sb3I6IHZhcigtLXdoaXRlKTtcbiAgZm9udC1zaXplOiAyOHB4O1xuICBmb250LXdlaWdodDogNjAwO1xuICBoZWlnaHQ6IDMuNXJlbTtcbiAgbGluZS1oZWlnaHQ6IDMycHg7XG4gIG1hcmdpbi1ib3R0b206IDA7XG4gIG91dGxpbmU6IG5vbmU7XG4gIHBhZGRpbmc6IDAuNXJlbSAwLjc1cmVtO1xuICB3aWR0aDogMTAwJTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2VhcmNoLXdyYXBwZXIgZm9ybS5zZWFyY2ggaW5wdXQuc2VhcmNoLWlucHV0OjpwbGFjZWhvbGRlciB7XG4gIGNvbG9yOiByZ2JhKHZhcigtLXdoaXRlKSwgMC40KTtcbiAgb3BhY2l0eTogMTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2VhcmNoLXdyYXBwZXIgZm9ybS5zZWFyY2ggaW5wdXRbdHlwZT1zZWFyY2hdOjotbXMtY2xlYXIge1xuICBkaXNwbGF5OiBub25lO1xuICBoZWlnaHQ6IDA7XG4gIHdpZHRoOiAwO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5zZWFyY2gtd3JhcHBlciBmb3JtLnNlYXJjaCBpbnB1dFt0eXBlPXNlYXJjaF06Oi1tcy1yZXZlYWwge1xuICBkaXNwbGF5OiBub25lO1xuICBoZWlnaHQ6IDA7XG4gIHdpZHRoOiAwO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5zZWFyY2gtd3JhcHBlciBmb3JtLnNlYXJjaCBpbnB1dFt0eXBlPXNlYXJjaF06Oi13ZWJraXQtc2VhcmNoLWRlY29yYXRpb24sXG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLnNlYXJjaC13cmFwcGVyIGZvcm0uc2VhcmNoIGlucHV0W3R5cGU9c2VhcmNoXTo6LXdlYmtpdC1zZWFyY2gtY2FuY2VsLWJ1dHRvbixcbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2VhcmNoLXdyYXBwZXIgZm9ybS5zZWFyY2ggaW5wdXRbdHlwZT1zZWFyY2hdOjotd2Via2l0LXNlYXJjaC1yZXN1bHRzLWJ1dHRvbixcbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2VhcmNoLXdyYXBwZXIgZm9ybS5zZWFyY2ggaW5wdXRbdHlwZT1zZWFyY2hdOjotd2Via2l0LXNlYXJjaC1yZXN1bHRzLWRlY29yYXRpb24ge1xuICBkaXNwbGF5OiBub25lO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5zZWFyY2gtd3JhcHBlciBmb3JtLnNlYXJjaCAuc2VhcmNoLXN1Ym1pdCB7XG4gIC13ZWJraXQtYXBwZWFyYW5jZTogbm9uZTtcbiAgcG9zaXRpb246IGFic29sdXRlO1xuICByaWdodDogMC41cmVtO1xuICB0b3A6IDAuMjVyZW07XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLnNlYXJjaC13cmFwcGVyIGZvcm0uc2VhcmNoIC5zZWFyY2gtc3VibWl0IHN2ZyB7XG4gIGJhY2tncm91bmQtY29sb3I6ICMxNDJkNWI7XG4gIGhlaWdodDogM3JlbTtcbiAgc3Ryb2tlOiB2YXIoLS13aGl0ZSk7XG4gIHdpZHRoOiAzcmVtO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5zZWFyY2gtd3JhcHBlciAuc3VnZ2VzdGlvbnMge1xuICBwYWRkaW5nLXRvcDogMy44NzVyZW07XG4gIHdpZHRoOiAzMHJlbTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2VhcmNoLXdyYXBwZXIgLnN1Z2dlc3Rpb25zIC5zdC1uYXYtcmVzdWx0cy1jb250YWluZXIgLnNlYXJjaC1yZXN1bHQgZW0ge1xuICBmb250LXN0eWxlOiBub3JtYWw7XG4gIGZvbnQtd2VpZ2h0OiA5MDA7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLnNlYXJjaC13cmFwcGVyIC5zdWdnZXN0aW9ucyAuc3QtbmF2LXJlc3VsdHMtY29udGFpbmVyIC5zdC1sb2FkaW5nLW1lc3NhZ2Uge1xuICBjb2xvcjogdmFyKC0td2hpdGUpO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5zZWFyY2gtd3JhcHBlciAuc3VnZ2VzdGlvbnMgLnJlc3VsdHMtaGVhZGVyIHtcbiAgLXdlYmtpdC1hbGlnbi1pdGVtczogY2VudGVyO1xuICBhbGlnbi1pdGVtczogY2VudGVyO1xuICAtd2Via2l0LWJveC1hbGlnbjogY2VudGVyO1xuICAtd2Via2l0LWJveC1wYWNrOiBqdXN0aWZ5O1xuICBkaXNwbGF5OiAtd2Via2l0LWJveDtcbiAgZGlzcGxheTogLXdlYmtpdC1mbGV4O1xuICBkaXNwbGF5OiAtbXMtZmxleGJveDtcbiAgZGlzcGxheTogZmxleDtcbiAgLW1zLWZsZXgtYWxpZ246IGNlbnRlcjtcbiAgLW1zLWZsZXgtcGFjazoganVzdGlmeTtcbiAgLXdlYmtpdC1qdXN0aWZ5LWNvbnRlbnQ6IHNwYWNlLWJldHdlZW47XG4gIGp1c3RpZnktY29udGVudDogc3BhY2UtYmV0d2VlbjtcbiAgbWFyZ2luLWJvdHRvbTogMXJlbTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2VhcmNoLXdyYXBwZXIgLnN1Z2dlc3Rpb25zIC5yZXN1bHRzLWhlYWRlciBhOmhvdmVyIHtcbiAgY29sb3I6IHZhcigtLXdoaXRlKTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2VhcmNoLXdyYXBwZXIgLnN1Z2dlc3Rpb25zIC5yZXN1bHRzLWhlYWRlciAucG9wdWxhcixcbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2VhcmNoLXdyYXBwZXIgLnN1Z2dlc3Rpb25zIC5yZXN1bHRzLWhlYWRlciAuc3VnZ2VzdGVkIHtcbiAgY29sb3I6IHJnYmEoMjU1LCAyNTUsIDI1NSwgMC43KTtcbiAgZm9udC13ZWlnaHQ6IDYwMDtcbiAgbGV0dGVyLXNwYWNpbmc6IDAuMXJlbTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2VhcmNoLXdyYXBwZXIgLnN1Z2dlc3Rpb25zIC5yZXN1bHRzLWhlYWRlciAuYWxsLXJlc3VsdHMtbGluayB7XG4gIGNvbG9yOiB2YXIoLS13aGl0ZSk7XG4gIGZvbnQtc2l6ZTogMXJlbTtcbiAgbGluZS1oZWlnaHQ6IDI0cHg7XG4gIG9wYWNpdHk6IDAuNztcbiAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5zZWFyY2gtd3JhcHBlciAuc3VnZ2VzdGlvbnMgLnN1Z2dlc3Rpb24tbGlua3Mge1xuICAtd2Via2l0LWJveC1wYWNrOiBqdXN0aWZ5O1xuICBkaXNwbGF5OiAtd2Via2l0LWJveDtcbiAgZGlzcGxheTogLXdlYmtpdC1mbGV4O1xuICBkaXNwbGF5OiAtbXMtZmxleGJveDtcbiAgZGlzcGxheTogZmxleDtcbiAgLW1zLWZsZXgtcGFjazoganVzdGlmeTtcbiAgLXdlYmtpdC1qdXN0aWZ5LWNvbnRlbnQ6IHNwYWNlLWJldHdlZW47XG4gIGp1c3RpZnktY29udGVudDogc3BhY2UtYmV0d2VlbjtcbiAgd2lkdGg6IDMxcmVtO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5zZWFyY2gtd3JhcHBlciAuc3VnZ2VzdGlvbnMgLnN1Z2dlc3Rpb24tbGlua3MgLnV0aWxpdHktbmF2LWxpbmsge1xuICAtd2Via2l0LWFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gIGJvcmRlci1yYWRpdXM6IDRweDtcbiAgLXdlYmtpdC1ib3gtYWxpZ246IGNlbnRlcjtcbiAgY29sb3I6IHZhcigtLWFjY2VudC0xMCk7XG4gIGRpc3BsYXk6IC13ZWJraXQtYm94O1xuICBkaXNwbGF5OiAtd2Via2l0LWZsZXg7XG4gIGRpc3BsYXk6IC1tcy1mbGV4Ym94O1xuICBkaXNwbGF5OiBmbGV4O1xuICAtbXMtZmxleC1hbGlnbjogY2VudGVyO1xuICBmb250LXdlaWdodDogNjAwO1xuICBsaW5lLWhlaWdodDogMjBweDtcbiAgb3BhY2l0eTogMC43O1xuICBwYWRkaW5nOiAwLjYyNXJlbTtcbiAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xuICAtd2Via2l0LXRyYW5zaXRpb246IGJhY2tncm91bmQtY29sb3IgMC4ycyBlYXNlLCBib3JkZXItY29sb3IgMC4ycyBlYXNlLCBvcGFjaXR5IDAuMnMgZWFzZTtcbiAgdHJhbnNpdGlvbjogYmFja2dyb3VuZC1jb2xvciAwLjJzIGVhc2UsIGJvcmRlci1jb2xvciAwLjJzIGVhc2UsIG9wYWNpdHkgMC4ycyBlYXNlO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5zZWFyY2gtd3JhcHBlciAuc3VnZ2VzdGlvbnMgLnN1Z2dlc3Rpb24tbGlua3MgLnV0aWxpdHktbmF2LWxpbmsuc2VhcmNoLXJlY29tbWVuZGF0aW9uIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogcmdiYSgyNTUsIDI1NSwgMjU1LCAwLjEpO1xuICBib3JkZXItY29sb3I6IHJnYmEoMjU1LCAyNTUsIDI1NSwgMCk7XG4gIGJvcmRlci1zdHlsZTogc29saWQ7XG4gIGJvcmRlci13aWR0aDogMXB4O1xuICBjb2xvcjogdmFyKC0td2hpdGUpO1xuICBtYXJnaW4tcmlnaHQ6IDFyZW07XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLnNlYXJjaC13cmFwcGVyIC5zdWdnZXN0aW9ucyAuc3VnZ2VzdGlvbi1saW5rcyAudXRpbGl0eS1uYXYtbGluay5zZWFyY2gtcmVjb21tZW5kYXRpb246aG92ZXIge1xuICBib3JkZXI6IDFweCBzb2xpZCB2YXIoLS13aGl0ZSk7XG4gIG9wYWNpdHk6IDE7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLnNlYXJjaC13cmFwcGVyIC5zdWdnZXN0aW9ucyAuc2VhcmNoLXJlc3VsdHMgLnNlYXJjaC1yZXN1bHQge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiByZ2JhKDI1NSwgMjU1LCAyNTUsIDAuMSk7XG4gIGJvcmRlci1jb2xvcjogcmdiYSgyNTUsIDI1NSwgMjU1LCAwKTtcbiAgYm9yZGVyLXJhZGl1czogOHB4O1xuICBib3JkZXItc3R5bGU6IHNvbGlkO1xuICBib3JkZXItd2lkdGg6IDFweDtcbiAgY29sb3I6IHZhcigtLXdoaXRlKTtcbiAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICBtYXJnaW4tYm90dG9tOiAxLjVyZW07XG4gIHBhZGRpbmc6IDFyZW07XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgLXdlYmtpdC10cmFuc2l0aW9uOiBib3JkZXItY29sb3IgMC4ycyBlYXNlO1xuICB0cmFuc2l0aW9uOiBib3JkZXItY29sb3IgMC4ycyBlYXNlO1xuICB3aWR0aDogMTAwJTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2VhcmNoLXdyYXBwZXIgLnN1Z2dlc3Rpb25zIC5zZWFyY2gtcmVzdWx0cyAuc2VhcmNoLXJlc3VsdDpob3ZlciB7XG4gIGJvcmRlci1jb2xvcjogdmFyKC0td2hpdGUpO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5zZWFyY2gtd3JhcHBlciAuc3VnZ2VzdGlvbnMgLnNlYXJjaC1yZXN1bHRzIC5zZWFyY2gtcmVzdWx0IC5zZWFyY2gtcmVzdWx0LWhlYWRpbmcge1xuICBjb2xvcjogdmFyKC0td2hpdGUpO1xuICBmb250LXdlaWdodDogNjAwO1xuICBsaW5lLWhlaWdodDogMjhweDtcbiAgbWFyZ2luLWJvdHRvbTogMDtcbiAgbWFyZ2luLXRvcDogMDtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2VhcmNoLXdyYXBwZXIgLnN1Z2dlc3Rpb25zIC5zZWFyY2gtcmVzdWx0cyAuc2VhcmNoLXJlc3VsdCAuc2VhcmNoLXJlc3VsdC11cmwge1xuICBmb250LXdlaWdodDogNjAwO1xuICBsaW5lLWhlaWdodDogMjBweDtcbiAgb3BhY2l0eTogMC44O1xuICBwYWRkaW5nLXRvcDogMC43NXJlbTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2VhcmNoLXdyYXBwZXIgLnN1Z2dlc3Rpb25zIC5zZWFyY2gtcmVzdWx0cyAuc3Qtbm8tcmVzdWx0cyxcbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2VhcmNoLXdyYXBwZXIgLnN1Z2dlc3Rpb25zIC5zZWFyY2gtcmVzdWx0cyAuc3Qtc3BlbGxpbmctc3VnZ2VzdGlvbiB7XG4gIGNvbG9yOiB2YXIoLS13aGl0ZSk7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLnNlYXJjaC13cmFwcGVyIC5jbG9zZS1zZWFyY2gge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiByZ2JhKDI1NSwgMjU1LCAyNTUsIDAuMSk7XG4gIGJvcmRlci1jb2xvcjogcmdiYSgyNTUsIDI1NSwgMjU1LCAwKTtcbiAgYm9yZGVyLXJhZGl1czogMnB4O1xuICBib3JkZXItc3R5bGU6IHNvbGlkO1xuICBib3JkZXItd2lkdGg6IDFweDtcbiAgYm90dG9tOiBhdXRvO1xuICBkaXNwbGF5OiBmbGV4O1xuICBoZWlnaHQ6IDJyZW07XG4gIGxlZnQ6IGF1dG87XG4gIHBhZGRpbmc6IDAuNXJlbTtcbiAgcG9zaXRpb246IGFic29sdXRlO1xuICByaWdodDogMy41cmVtO1xuICB0b3A6IDMuNXJlbTtcbiAgd2lkdGg6IDJyZW07XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLnNlYXJjaC13cmFwcGVyIC5jbG9zZS1zZWFyY2g6aG92ZXIge1xuICBib3JkZXI6IDFweCBzb2xpZCB2YXIoLS13aGl0ZSk7XG4gIG9wYWNpdHk6IDE7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLnNraXAtdG8tZm9vdGVyLXdyYXBwZXIge1xuICBiYWNrZ3JvdW5kOiB2YXIoLS13aGl0ZSk7XG4gIGJvcmRlci1yYWRpdXM6IDRweDtcbiAgYm94LXNoYWRvdzogMHB4IDEuMXB4IDQuMDVweCAtMC42NnB4IHJnYmEoMCwgMCwgMCwgMC4xNCksIDBweCAzcHggNC41cHggMC4zcHggcmdiYSgwLCAwLCAwLCAwLjAzNiksIDBweCAyLjlweCA2cHggMC4ycHggcmdiYSgwLCAwLCAwLCAwLjA2KTtcbiAgbGVmdDogLTUwJTtcbiAgcGFkZGluZzogMC4yNXJlbSAwLjc1cmVtO1xuICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gIHRyYW5zZm9ybTogdHJhbnNsYXRlWCgtNTAlKTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2tpcC10by1mb290ZXItd3JhcHBlciAuc2tpcC10by1mb290ZXItdGV4dCB7XG4gIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdC1hY3RpdmUpO1xuICBmb250LXNpemU6IDE5cHg7XG4gIGZvbnQtd2VpZ2h0OiA2MDA7XG4gIHRleHQtYWxpZ246IGNlbnRlcjtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuc2tpcC10by1mb290ZXItd3JhcHBlcjpmb2N1cyB7XG4gIGxlZnQ6IDUwJTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYge1xuICBoZWlnaHQ6IDNyZW07XG4gIG1hcmdpbjogMCBhdXRvO1xuICBtYXgtd2lkdGg6IDEzNjZweDtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICB3aWR0aDogMTAwJTtcbiAgei1pbmRleDogMjtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLmNvbnRlbnQtd3JhcHBlciB7XG4gIGhlaWdodDogMTAwJTtcbiAgd2lkdGg6IDEwMCU7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC5jb250ZW50LXdyYXBwZXIudXRpbGl0eSB7XG4gIGJvcmRlci1ib3R0b206IHNvbGlkIDFweCAjZGFkZWUzO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAudXRpbGl0eS1uYXYtbGVmdCAuaW5mby1mb3Ige1xuICBjb2xvcjogdmFyKC0tYWNjZW50LTEwKTtcbiAgZm9udC13ZWlnaHQ6IDYwMDtcbiAgb3BhY2l0eTogMC42O1xuICBwYWRkaW5nLXJpZ2h0OiAwLjVyZW07XG4gIHRleHQtYWxpZ246IGNlbnRlcjtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLnV0aWxpdHktbmF2LWxlZnQgLnV0aWxpdHktbmF2LWxpbmsge1xuICBib3JkZXItcmFkaXVzOiA0cHg7XG4gIGNvbG9yOiB2YXIoLS1hY2NlbnQtMTApO1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gIGZvbnQtd2VpZ2h0OiA2MDA7XG4gIG9wYWNpdHk6IDAuNztcbiAgcGFkZGluZzogMC42MjVyZW07XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgdHJhbnNpdGlvbi1kdXJhdGlvbjogMC4ycywgMC4ycywgMC4ycztcbiAgdHJhbnNpdGlvbi1wcm9wZXJ0eTogYmFja2dyb3VuZC1jb2xvciwgb3BhY2l0eSwgY29sb3I7XG4gIHRyYW5zaXRpb24tdGltaW5nLWZ1bmN0aW9uOiBlYXNlLCBlYXNlLCBlYXNlO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAudXRpbGl0eS1uYXYtbGVmdCAudXRpbGl0eS1uYXYtbGluazpob3ZlciB7XG4gIGJhY2tncm91bmQ6ICNlYmYyZmY7XG4gIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdC1hY3RpdmUpO1xuICBvcGFjaXR5OiAxO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAudXRpbGl0eS1uYXYtcmlnaHQge1xuICBtYXJnaW4tcmlnaHQ6IC0wLjVyZW07XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC51dGlsaXR5LW5hdi1yaWdodCAuZHJvcGRvd24ge1xuICBtYXJnaW4tbGVmdDogMXJlbTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biAubGFuZ3VhZ2UtZHJvcGRvd24tdG9nZ2xlIHtcbiAgY29sb3I6ICMyMjI7XG4gIGN1cnNvcjogcG9pbnRlcjtcbiAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICBtYXJnaW4tbGVmdDogYXV0bztcbiAgbWFyZ2luLXJpZ2h0OiBhdXRvO1xuICBwYWRkaW5nOiAxLjVyZW07XG4gIHBhZGRpbmctcmlnaHQ6IDIuNXJlbTtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICB0ZXh0LWFsaWduOiBsZWZ0O1xuICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gIC13ZWJraXQtdXNlci1zZWxlY3Q6IG5vbmU7XG4gIC1tb3otdXNlci1zZWxlY3Q6IG5vbmU7XG4gIC1tcy11c2VyLXNlbGVjdDogbm9uZTtcbiAgdXNlci1zZWxlY3Q6IG5vbmU7XG4gIHZlcnRpY2FsLWFsaWduOiB0b3A7XG4gIHdoaXRlLXNwYWNlOiBub3dyYXA7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC51dGlsaXR5LW5hdi1yaWdodCAuZHJvcGRvd24gLnV0aWxpdHktbmF2LWxpbmsubGFuZ3VhZ2Utc2VsZWN0b3Igc3ZnIHtcbiAgZmlsbDogdmFyKC0tYWNjZW50LTEwKTtcbiAgaGVpZ2h0OiAxcmVtO1xuICBtYXJnaW4tYm90dG9tOiAwLjA2MjVyZW07XG4gIG1hcmdpbi1yaWdodDogMC4yNXJlbTtcbiAgdHJhbnNpdGlvbi1kdXJhdGlvbjogMC4ycztcbiAgdHJhbnNpdGlvbi1wcm9wZXJ0eTogZmlsbDtcbiAgdHJhbnNpdGlvbi10aW1pbmctZnVuY3Rpb246IGVhc2U7XG4gIHdpZHRoOiAxcmVtO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAudXRpbGl0eS1uYXYtcmlnaHQgLmRyb3Bkb3duIC51dGlsaXR5LW5hdi1saW5rLmxhbmd1YWdlLXNlbGVjdG9yOmhvdmVyIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogI2ViZjJmZjtcbiAgY29sb3I6IHZhcigtLWFjdGlvbi1kZWZhdWx0LWFjdGl2ZSk7XG4gIG9wYWNpdHk6IDE7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC51dGlsaXR5LW5hdi1yaWdodCAuZHJvcGRvd24gLnV0aWxpdHktbmF2LWxpbmsubGFuZ3VhZ2Utc2VsZWN0b3I6aG92ZXIgc3ZnIHtcbiAgZmlsbDogdmFyKC0tYWN0aW9uLWRlZmF1bHQtYWN0aXZlKTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biAudXRpbGl0eS1uYXYtbGluayB7XG4gIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gIGJvcmRlci1yYWRpdXM6IDRweDtcbiAgY29sb3I6ICMwMDA7XG4gIGRpc3BsYXk6IGZsZXg7XG4gIGZvbnQtd2VpZ2h0OiA2MDA7XG4gIG9wYWNpdHk6IDAuNztcbiAgcGFkZGluZzogMC42MjVyZW07XG4gIHRyYW5zaXRpb24tZHVyYXRpb246IDAuMnMsIDAuMnMsIDAuMnM7XG4gIHRyYW5zaXRpb24tcHJvcGVydHk6IGNvbG9yLCBiYWNrZ3JvdW5kLWNvbG9yLCBvcGFjaXR5O1xuICB0cmFuc2l0aW9uLXRpbWluZy1mdW5jdGlvbjogZWFzZSwgZWFzZSwgZWFzZTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biAuZHJvcGRvd24tbGlzdC13cmFwcGVyIHtcbiAgZGlzcGxheTogbm9uZTtcbiAgcG9zaXRpb246IGFic29sdXRlO1xuICByaWdodDogMDtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biAuZHJvcGRvd24tbGlzdC13cmFwcGVyIC5kcm9wZG93bi1saXN0IHtcbiAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0td2hpdGUpO1xuICBib3JkZXItcmFkaXVzOiA0cHg7XG4gIGJveC1zaGFkb3c6IHJnYmEoMCwgMCwgMCwgMC4yMikgMHB4IDJweCA2cHggMHB4O1xuICBkaXNwbGF5OiBmbGV4O1xuICBmbGV4LWRpcmVjdGlvbjogY29sdW1uO1xuICBwYWRkaW5nOiAwLjVyZW0gMC4yNXJlbSAwIDAuMjVyZW07XG4gIHdpZHRoOiAxMi41cmVtO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAudXRpbGl0eS1uYXYtcmlnaHQgLmRyb3Bkb3duIC5kcm9wZG93bi1saXN0LXdyYXBwZXIgLmRyb3Bkb3duLWxpc3QgdWwge1xuICBwYWRkaW5nLWlubGluZS1zdGFydDogMDtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biAuZHJvcGRvd24tbGlzdC13cmFwcGVyIC5kcm9wZG93bi1saXN0IC5vc2ItbmF2LWl0ZW0ge1xuICBhbGlnbi1pdGVtczogY2VudGVyO1xuICBib3JkZXItcmFkaXVzOiA0cHg7XG4gIGRpc3BsYXk6IGZsZXg7XG4gIGZvbnQtd2VpZ2h0OiA2MDA7XG4gIG1hcmdpbi1ib3R0b206IDAuNXJlbTtcbiAgcGFkZGluZzogMC4yNXJlbSAwLjI1cmVtIDAuMjVyZW0gMS41cmVtO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAudXRpbGl0eS1uYXYtcmlnaHQgLmRyb3Bkb3duIC5kcm9wZG93bi1saXN0LXdyYXBwZXIgLmRyb3Bkb3duLWxpc3QgLm9zYi1uYXYtaXRlbTphY3RpdmUge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjZWJmMmZmO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAudXRpbGl0eS1uYXYtcmlnaHQgLmRyb3Bkb3duIC5kcm9wZG93bi1saXN0LXdyYXBwZXIgLmRyb3Bkb3duLWxpc3QgLm9zYi1uYXYtaXRlbTpmb2N1cyB7XG4gIGJhY2tncm91bmQtY29sb3I6ICNlYmYyZmY7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC51dGlsaXR5LW5hdi1yaWdodCAuZHJvcGRvd24gLmRyb3Bkb3duLWxpc3Qtd3JhcHBlciAuZHJvcGRvd24tbGlzdCAub3NiLW5hdi1pdGVtOmhvdmVyIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogI2ViZjJmZjtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biAuZHJvcGRvd24tbGlzdC13cmFwcGVyIC5kcm9wZG93bi1saXN0IC5vc2ItbmF2LWl0ZW0gLmxhbmd1YWdlLWVudHJ5LWxvbmctdGV4dCB7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTIpO1xuICB3aWR0aDogMTAwJTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biAuZHJvcGRvd24tbGlzdC13cmFwcGVyIC5kcm9wZG93bi1saXN0IC5vc2ItbmF2LWl0ZW0gLmxhbmd1YWdlLWVudHJ5LWxvbmctdGV4dDphY3RpdmUge1xuICBjb2xvcjogdmFyKC0tbmV1dHJhbC0yKTtcbiAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAudXRpbGl0eS1uYXYtcmlnaHQgLmRyb3Bkb3duIC5kcm9wZG93bi1saXN0LXdyYXBwZXIgLmRyb3Bkb3duLWxpc3QgLm9zYi1uYXYtaXRlbSAubGFuZ3VhZ2UtZW50cnktbG9uZy10ZXh0OnZpc2l0ZWQge1xuICBjb2xvcjogdmFyKC0tbmV1dHJhbC0yKTtcbiAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAudXRpbGl0eS1uYXYtcmlnaHQgLmRyb3Bkb3duIC5kcm9wZG93bi1saXN0LXdyYXBwZXIgLmRyb3Bkb3duLWxpc3QgLm9zYi1uYXYtaXRlbSAubGFuZ3VhZ2UtZW50cnktbG9uZy10ZXh0OmZvY3VzIHtcbiAgY29sb3I6IHZhcigtLW5ldXRyYWwtMik7XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biAuZHJvcGRvd24tbGlzdC13cmFwcGVyIC5kcm9wZG93bi1saXN0IC5vc2ItbmF2LWl0ZW0gLmxhbmd1YWdlLWVudHJ5LWxvbmctdGV4dDpob3ZlciB7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTIpO1xuICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC51dGlsaXR5LW5hdi1yaWdodCAuZHJvcGRvd24gLmRyb3Bkb3duLWxpc3Qtd3JhcHBlciAuZHJvcGRvd24tbGlzdCAub3NiLW5hdi1pdGVtLnNlbGVjdGVkIHtcbiAgcGFkZGluZy1sZWZ0OiAwLjQzNzVyZW07XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC51dGlsaXR5LW5hdi1yaWdodCAuZHJvcGRvd24gLmRyb3Bkb3duLWxpc3Qtd3JhcHBlciAuZHJvcGRvd24tbGlzdCAub3NiLW5hdi1pdGVtLnNlbGVjdGVkIC5sYW5ndWFnZS1lbnRyeS1sb25nLXRleHQge1xuICBjb2xvcjogIzAwNGFkNztcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biAuZHJvcGRvd24tbGlzdC13cmFwcGVyIC5kcm9wZG93bi1saXN0IC5zZWxlY3RlZC5vc2ItbmF2LWl0ZW06YmVmb3JlIHtcbiAgY29udGVudDogdXJsKFwiZGF0YTppbWFnZS9zdmcreG1sO2NoYXJzZXQ9VVMtQVNDSUksJTNDc3ZnJTIwd2lkdGglM0QlMjIxMiUyMiUyMGhlaWdodCUzRCUyMjklMjIlMjB2aWV3Qm94JTNEJTIyMCUyMDAlMjAxMiUyMDklMjIlMjBmaWxsJTNEJTIybm9uZSUyMiUyMHhtbG5zJTNEJTIyaHR0cCUzQS8vd3d3LnczLm9yZy8yMDAwL3N2ZyUyMiUzRSUwQSUzQ3BhdGglMjBmaWxsLXJ1bGUlM0QlMjJldmVub2RkJTIyJTIwY2xpcC1ydWxlJTNEJTIyZXZlbm9kZCUyMiUyMGQlM0QlMjJNOS42MjYyMyUyMDAuOTU4OTA5QzEwLjAxNjglMjAwLjU2ODM4NSUyMDEwLjY0OTklMjAwLjU2ODM4NSUyMDExLjA0MDQlMjAwLjk1ODkwOUMxMS40MzElMjAxLjM0OTQzJTIwMTEuNDMxJTIwMS45ODI2JTIwMTEuMDQwNCUyMDIuMzczMTJMNS4wNDEyNyUyMDguMzcyMjlDNS4wNDA5OSUyMDguMzcyNTclMjA1LjA0MDcyJTIwOC4zNzI4NSUyMDUuMDQwNDQlMjA4LjM3MzEyQzQuNjQ5OTIlMjA4Ljc2MzY1JTIwNC4wMTY3NSUyMDguNzYzNjUlMjAzLjYyNjIzJTIwOC4zNzMxMkwwLjI5Mjg5MyUyMDUuMDM5NzlDLTAuMDk3NjMxMSUyMDQuNjQ5MjclMjAtMC4wOTc2MzExJTIwNC4wMTYxJTIwMC4yOTI4OTMlMjAzLjYyNTU4QzAuNjgzNDE3JTIwMy4yMzUwNSUyMDEuMzE2NTglMjAzLjIzNTA1JTIwMS43MDcxMSUyMDMuNjI1NThMNC4zMzMzMyUyMDYuMjUxOEw5LjYyNjIzJTIwMC45NTg5MDlaJTIyJTIwZmlsbCUzRCUyMiUyMzAwNEFENyUyMi8lM0UlMEElM0Mvc3ZnJTNFJTBBXCIpO1xuICBtYXJnaW4tcmlnaHQ6IDAuMzEyNXJlbTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biAuZHJvcGRvd24tbGlzdC13cmFwcGVyLmxpc3Qtb3BlbiB7XG4gIGRpc3BsYXk6IGJsb2NrO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAudXRpbGl0eS1uYXYtcmlnaHQgLnNlYXJjaC1idXR0b24ge1xuICBib3JkZXItcmFkaXVzOiA0cHg7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgbWFyZ2luLWxlZnQ6IDAuNXJlbTtcbiAgbWF4LXdpZHRoOiAxMDAlO1xuICBvcGFjaXR5OiAwLjc7XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgdHJhbnNpdGlvbi1kdXJhdGlvbjogMC4ycywgMC4ycywgMC4ycztcbiAgdHJhbnNpdGlvbi1wcm9wZXJ0eTogb3BhY2l0eSwgYmFja2dyb3VuZC1jb2xvciwgc3Ryb2tlO1xuICB0cmFuc2l0aW9uLXRpbWluZy1mdW5jdGlvbjogZWFzZSwgZWFzZSwgZWFzZTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLnV0aWxpdHktbmF2LXJpZ2h0IC5zZWFyY2gtYnV0dG9uIHN2ZyB7XG4gIGhlaWdodDogMi41cmVtO1xuICBzdHJva2U6IHZhcigtLWFjY2VudC0xMCk7XG4gIHRyYW5zaXRpb24tZHVyYXRpb246IDAuMnM7XG4gIHRyYW5zaXRpb24tcHJvcGVydHk6IHN0cm9rZTtcbiAgdHJhbnNpdGlvbi10aW1pbmctZnVuY3Rpb246IGVhc2U7XG4gIHdpZHRoOiAyLjVyZW07XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC51dGlsaXR5LW5hdi1yaWdodCAuc2VhcmNoLWJ1dHRvbjpob3ZlciB7XG4gIGJhY2tncm91bmQtY29sb3I6ICNlYmYyZmY7XG4gIG9wYWNpdHk6IDE7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC51dGlsaXR5LW5hdi1yaWdodCAuc2VhcmNoLWJ1dHRvbjpob3ZlciBzdmcge1xuICBzdHJva2U6IHZhcigtLWFjdGlvbi1kZWZhdWx0LWFjdGl2ZSk7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLmNvbnRhY3Qtc2FsZXMsXG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLmNvbnRhY3Qtc2FsZXMtY29udGFpbmVyIC53LWJ1dHRvbiB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLWFjY2VudC02KTtcbiAgYm9yZGVyLXJhZGl1czogNHB4O1xuICBjb2xvcjogdmFyKC0td2hpdGUpO1xuICBmb250LXNpemU6IDFyZW07XG4gIGZvbnQtd2VpZ2h0OiA2MDA7XG4gIGxpbmUtaGVpZ2h0OiAxLjVyZW07XG4gIG1hcmdpbi1sZWZ0OiAxcmVtO1xuICBwYWRkaW5nOiAwLjVyZW0gMXJlbTtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gIHdoaXRlLXNwYWNlOiBub3dyYXA7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLmNvbnRhY3Qtc2FsZXM6aG92ZXIsXG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLmNvbnRhY3Qtc2FsZXMtY29udGFpbmVyIC53LWJ1dHRvbjpob3ZlciB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLWFjdGlvbi1zZWNvbmRhcnktaG92ZXIpO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiB7XG4gIGhlaWdodDogNHJlbTtcbiAgbWFyZ2luOiAwIGF1dG87XG4gIG1heC13aWR0aDogMTM2NnB4O1xuICBwYWRkaW5nOiAwO1xuICB3aWR0aDogMTAwJTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAucHJpbWFyeS1uYXYgLmNvbnRlbnQtd3JhcHBlciB7XG4gIGhlaWdodDogMTAwJTtcbiAganVzdGlmeS1jb250ZW50OiBzcGFjZS1iZXR3ZWVuO1xuICBwYWRkaW5nOiAwIDEuNXJlbTtcbiAgd2lkdGg6IDEwMCU7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLmxpZmVyYXktbG9nbyB7XG4gIGJvcmRlci1yYWRpdXM6IDRweDtcbiAgd2lkdGg6IDkuNXJlbTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAucHJpbWFyeS1uYXYgLmNvbnRlbnQtd3JhcHBlciAubGlmZXJheS1sb2dvIHN2ZyB7XG4gIGhlaWdodDogM3JlbTtcbiAgd2lkdGg6IDEwMCU7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLmxpZmVyYXktbG9nbyBzdmc6bGFzdC1jaGlsZCB7XG4gIGNvbG9yOiB2YXIoLS1ibGFjayk7XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLmxpZmVyYXktbG9nbzpob3ZlciB7XG4gIGJhY2tncm91bmQtY29sb3I6ICNlYmYyZmY7XG59XG5AbWVkaWEgc2NyZWVuIGFuZCAobWF4LXdpZHRoOiA5OTFweCkge1xuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLm5hdi1pdGVtcy13cmFwcGVyIHtcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgIGZsZXgtZGlyZWN0aW9uOiBjb2x1bW47XG4gICAgaGVpZ2h0OiAxMDB2aDtcbiAgICBsZWZ0OiAwO1xuICAgIG92ZXJmbG93OiBzY3JvbGw7XG4gICAgcGFkZGluZy1ib3R0b206IDcuNXJlbTtcbiAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgcmlnaHQ6IDA7XG4gICAgdG9wOiAwO1xuICAgIHRyYW5zZm9ybTogdHJhbnNsYXRlM2QoMCwgLTEwMCUsIDApIHNjYWxlM2QoMSwgMSwgMSkgcm90YXRlWCgwZGVnKSByb3RhdGVZKDBkZWcpIHJvdGF0ZVooMGRlZykgc2tldygwZGVnLCAwZGVnKTtcbiAgICB0cmFuc2Zvcm0tc3R5bGU6IHByZXNlcnZlLTNkO1xuICAgIHotaW5kZXg6IC0xO1xuICB9XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLm5hdi1pdGVtcy13cmFwcGVyIHtcbiAgYWxpZ24taXRlbXM6IHN0cmV0Y2g7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLXdoaXRlKTtcbiAgcGFkZGluZy10b3A6IDVyZW07XG59XG4uZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLm5hdi1pdGVtcy13cmFwcGVyIC51bmRlcmxpbmUtY29udGFpbmVyIHtcbiAgZGlzcGxheTogbm9uZTtcbn1cbi5mLW5hdmlnYXRpb24tcHJpbWFyeSAubW9iaWxlLWJ1dHRvbnMge1xuICBib3R0b206IDAuNzVyZW07XG4gIHBhZGRpbmc6IDAgMS41cmVtO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5tb2JpbGUtYnV0dG9ucyAuYnV0dG9uLXRleHQtY2xvc2Uge1xuICBkaXNwbGF5OiBub25lO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5tb2JpbGUtYnV0dG9ucyAubW9iaWxlLW1lbnUubWVudS1vcGVuIC5idXR0b24tdGV4dC1jbG9zZSB7XG4gIGRpc3BsYXk6IGJsb2NrO1xufVxuLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5tb2JpbGUtYnV0dG9ucyAubW9iaWxlLW1lbnUubWVudS1vcGVuIC5idXR0b24tdGV4dC1tZW51IHtcbiAgZGlzcGxheTogbm9uZTtcbn1cbkBtZWRpYSAobWF4LXdpZHRoOiA1OTlweCkge1xuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUge1xuICAgIGJveC1zaGFkb3c6IG5vbmU7XG4gICAgZ3JpZC1yb3ctZ2FwOiAwO1xuICAgIGhlaWdodDogYXV0bztcbiAgICBtYXgtaGVpZ2h0OiAwO1xuICAgIG9wYWNpdHk6IDE7XG4gICAgb3ZlcmZsb3c6IGhpZGRlbjtcbiAgICBwYWRkaW5nOiAwO1xuICAgIHBvc2l0aW9uOiBzdGF0aWM7XG4gICAgdHJhbnNmb3JtOiBub25lO1xuICAgIHRyYW5zaXRpb246IG1heC1oZWlnaHQgMC4zcyBjdWJpYy1iZXppZXIoMC4yMywgMSwgMC4zMiwgMSk7XG4gICAgdmlzaWJpbGl0eTogdmlzaWJsZTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUgLmFkdC1zdWJtZW51LW91dGVyLXdyYXBwZXIgLmFkdC1zdWJtZW51LWlubmVyLXdyYXBwZXIge1xuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgZmxleC1kaXJlY3Rpb246IGNvbHVtbjtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUgLmFkdC1zdWJtZW51LXNlY3Rpb24ge1xuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgZmxleC1kaXJlY3Rpb246IGNvbHVtbjtcbiAgICBncmlkLXRlbXBsYXRlLXJvd3M6IG5vbmU7XG4gICAgcGFkZGluZy1sZWZ0OiAxLjVyZW07XG4gICAgcGFkZGluZy1yaWdodDogMnJlbTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtaGVhZGVyIHtcbiAgICBib3JkZXItd2lkdGg6IDA7XG4gICAgbWFyZ2luLWJvdHRvbTogMDtcbiAgICBwYWRkaW5nLWJvdHRvbTogMXJlbTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50IHtcbiAgICBwYWRkaW5nLWJvdHRvbTogMi41cmVtO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1pdGVtLWNvbnRlbnQ6bm90KC5pbWFnZS10eXBlKSB7XG4gICAgYm9yZGVyLWxlZnQ6IHNvbGlkIDJweCB2YXIoLS1uZXV0cmFsLTcpO1xuICAgIG1heC13aWR0aDogbm9uZTtcbiAgICBwYWRkaW5nLWxlZnQ6IDFyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24ge1xuICAgIGRpc3BsYXk6IG5vbmU7XG4gICAgZ3JpZC1yb3ctZ2FwOiAwO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAubmF2IC5zZWFyY2gtd3JhcHBlci5zZWFyY2gtb3BlbiB7XG4gICAgaGVpZ2h0OiAxMDB2aDtcbiAgICBvdmVyZmxvdzogYXV0bztcbiAgICBwYWRkaW5nOiA1cmVtIDEuNXJlbSAxLjVyZW07XG4gICAgei1pbmRleDogNDtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLm5hdiAuc2VhcmNoLXdyYXBwZXIuc2VhcmNoLW9wZW4gLmNsb3NlLXNlYXJjaCB7XG4gICAgcmlnaHQ6IDEuNXJlbTtcbiAgICB0b3A6IDFyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5uYXYgLnNlYXJjaC13cmFwcGVyLnNlYXJjaC1vcGVuIC5zZWFyY2gge1xuICAgIHdpZHRoOiAxMDAlO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAubmF2IC5zZWFyY2gtd3JhcHBlci5zZWFyY2gtb3BlbiAuc2VhcmNoIC5zZWFyY2gtaW5wdXQgPiAuc2VhcmNoLXN1Ym1pdCB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tYWNjZW50LTEwKTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLm5hdiAuc2VhcmNoLXdyYXBwZXIuc2VhcmNoLW9wZW4gLnN1Z2dlc3Rpb25zIHtcbiAgICB3aWR0aDogMTAwJTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLm5hdiAuc2VhcmNoLXdyYXBwZXIuc2VhcmNoLW9wZW4gLnN1Z2dlc3Rpb25zIC5zdWdnZXN0aW9uLWxpbmtzIHtcbiAgICBqdXN0aWZ5LWNvbnRlbnQ6IGNlbnRlcjtcbiAgICB3aWR0aDogMTAwJTtcbiAgfVxufVxuQG1lZGlhIChtYXgtd2lkdGg6IDU5OXB4KSBhbmQgKG1heC13aWR0aDogNDAwcHgpIHtcbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5uYXYgLnNlYXJjaC13cmFwcGVyLnNlYXJjaC1vcGVuIC5zdWdnZXN0aW9ucyAuc3VnZ2VzdGlvbi1saW5rcyB7XG4gICAgZmxleC13cmFwOiB3cmFwO1xuICAgIGp1c3RpZnktY29udGVudDogc3BhY2UtYmV0d2VlbjtcbiAgICB0ZXh0LWFsaWduOiBjZW50ZXI7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5uYXYgLnNlYXJjaC13cmFwcGVyLnNlYXJjaC1vcGVuIC5zdWdnZXN0aW9ucyAuc3VnZ2VzdGlvbi1saW5rcyBhOmxhc3QtY2hpbGQge1xuICAgIG1hcmdpbi10b3A6IDFyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5uYXYgLnNlYXJjaC13cmFwcGVyLnNlYXJjaC1vcGVuIC5zdWdnZXN0aW9ucyAuc3VnZ2VzdGlvbi1saW5rcyBhLnV0aWxpdHktbmF2LWxpbmsuc2VhcmNoLXJlY29tbWVuZGF0aW9uIHtcbiAgICBqdXN0aWZ5LWNvbnRlbnQ6IGNlbnRlcjtcbiAgICBtYXJnaW4tcmlnaHQ6IDA7XG4gICAgd2lkdGg6IDMwJTtcbiAgfVxufVxuQG1lZGlhIChtYXgtd2lkdGg6IDU5OXB4KSB7XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYge1xuICAgIGJhY2tncm91bmQtY29sb3I6IHZhcigtLXdoaXRlKTtcbiAgICBib3JkZXItYm90dG9tOiAxcHggc29saWQgdmFyKC0tbmV1dHJhbC04KTtcbiAgICBkaXNwbGF5OiBibG9jaztcbiAgICBoZWlnaHQ6IDRyZW07XG4gICAgcGFkZGluZzogMC43NXJlbSAxLjVyZW07XG4gICAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAgIHotaW5kZXg6IDM7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIHtcbiAgICBoZWlnaHQ6IDEwMCU7XG4gICAgbWFyZ2luLWxlZnQ6IGF1dG87XG4gICAgbWFyZ2luLXJpZ2h0OiBhdXRvO1xuICAgIG1heC13aWR0aDogMTI0MHB4O1xuICAgIHdpZHRoOiAxMDAlO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLmNvbnRlbnQtd3JhcHBlci51dGlsaXR5IHtcbiAgICBib3JkZXItd2lkdGg6IDA7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC5saWZlcmF5LWxvZ28ge1xuICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgIHdpZHRoOiA3LjVyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC5saWZlcmF5LWxvZ28gc3ZnIHtcbiAgICBoZWlnaHQ6IDNyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC5saWZlcmF5LWxvZ28gc3ZnOmxhc3QtY2hpbGQge1xuICAgIGNvbG9yOiB2YXIoLS1ibGFjayk7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC51dGlsaXR5LW5hdi1sZWZ0IHtcbiAgICBkaXNwbGF5OiBub25lO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLmNvbnRlbnQtd3JhcHBlciAudXRpbGl0eS1uYXYtcmlnaHQge1xuICAgIG1hcmdpbi1yaWdodDogLTAuNXJlbTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC5jb250ZW50LXdyYXBwZXIgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biB7XG4gICAgbWFyZ2luLWxlZnQ6IDFyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC51dGlsaXR5LW5hdi1yaWdodCAuZHJvcGRvd24gLmxhbmd1YWdlLWRyb3Bkb3duLXRvZ2dsZSB7XG4gICAgY29sb3I6ICMyMjI7XG4gICAgY3Vyc29yOiBwb2ludGVyO1xuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICBtYXJnaW4tbGVmdDogYXV0bztcbiAgICBtYXJnaW4tcmlnaHQ6IGF1dG87XG4gICAgcGFkZGluZzogMS41cmVtO1xuICAgIHBhZGRpbmctcmlnaHQ6IDIuNXJlbTtcbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgdGV4dC1hbGlnbjogbGVmdDtcbiAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gICAgLXdlYmtpdC11c2VyLXNlbGVjdDogbm9uZTtcbiAgICAtbW96LXVzZXItc2VsZWN0OiBub25lO1xuICAgIC1tcy11c2VyLXNlbGVjdDogbm9uZTtcbiAgICB1c2VyLXNlbGVjdDogbm9uZTtcbiAgICB2ZXJ0aWNhbC1hbGlnbjogdG9wO1xuICAgIHdoaXRlLXNwYWNlOiBub3dyYXA7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC51dGlsaXR5LW5hdi1yaWdodCAuZHJvcGRvd24gLnV0aWxpdHktbmF2LWxpbmsubGFuZ3VhZ2Utc2VsZWN0b3Igc3ZnIHtcbiAgICBmaWxsOiB2YXIoLS1hY2NlbnQtMTApO1xuICAgIGhlaWdodDogMXJlbTtcbiAgICBtYXJnaW4tYm90dG9tOiAwLjA2MjVyZW07XG4gICAgbWFyZ2luLXJpZ2h0OiAwLjI1cmVtO1xuICAgIHRyYW5zaXRpb24tZHVyYXRpb246IDIwMDtcbiAgICB0cmFuc2l0aW9uLXByb3BlcnR5OiBmaWxsO1xuICAgIHRyYW5zaXRpb24tdGltaW5nLWZ1bmN0aW9uOiBlYXNlO1xuICAgIHdpZHRoOiAxcmVtO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLmNvbnRlbnQtd3JhcHBlciAudXRpbGl0eS1uYXYtcmlnaHQgLmRyb3Bkb3duIC51dGlsaXR5LW5hdi1saW5rLmxhbmd1YWdlLXNlbGVjdG9yOmhvdmVyIHtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZWJmMmZmO1xuICAgIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdC1hY3RpdmUpO1xuICAgIG9wYWNpdHk6IDE7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC51dGlsaXR5LW5hdi1yaWdodCAuZHJvcGRvd24gLnV0aWxpdHktbmF2LWxpbmsubGFuZ3VhZ2Utc2VsZWN0b3I6aG92ZXIgc3ZnIHtcbiAgICBmaWxsOiB2YXIoLS1hY3Rpb24tZGVmYXVsdC1hY3RpdmUpO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLmNvbnRlbnQtd3JhcHBlciAudXRpbGl0eS1uYXYtcmlnaHQgLmRyb3Bkb3duIC51dGlsaXR5LW5hdi1saW5rIHtcbiAgICBhbGlnbi1pdGVtczogY2VudGVyO1xuICAgIGJvcmRlci1yYWRpdXM6IDRweDtcbiAgICBjb2xvcjogIzAwMDtcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgIGZvbnQtd2VpZ2h0OiA2MDA7XG4gICAgb3BhY2l0eTogMC43O1xuICAgIHBhZGRpbmc6IDAuNjI1cmVtO1xuICAgIHRyYW5zaXRpb24tZHVyYXRpb246IDAuMnMsIDAuMnMsIDAuMnM7XG4gICAgdHJhbnNpdGlvbi1wcm9wZXJ0eTogY29sb3IsIGJhY2tncm91bmQtY29sb3IsIG9wYWNpdHk7XG4gICAgdHJhbnNpdGlvbi10aW1pbmctZnVuY3Rpb246IGVhc2UsIGVhc2UsIGVhc2U7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC51dGlsaXR5LW5hdi1yaWdodCAuZHJvcGRvd24gLmRyb3Bkb3duLWxpc3Qtd3JhcHBlciB7XG4gICAgZGlzcGxheTogbm9uZTtcbiAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgcmlnaHQ6IDA7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC51dGlsaXR5LW5hdi1yaWdodCAuZHJvcGRvd24gLmRyb3Bkb3duLWxpc3Qtd3JhcHBlciAuZHJvcGRvd24tbGlzdCB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0td2hpdGUpO1xuICAgIGJvcmRlci1yYWRpdXM6IDRweDtcbiAgICBib3gtc2hhZG93OiByZ2JhKDAsIDAsIDAsIDAuMjIpIDBweCAycHggNnB4IDBweDtcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgIGZsZXgtZGlyZWN0aW9uOiBjb2x1bW47XG4gICAgcGFkZGluZzogMC41cmVtIDAuMjVyZW0gMCAwLjI1cmVtO1xuICAgIHdpZHRoOiAxMi41cmVtO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLmNvbnRlbnQtd3JhcHBlciAudXRpbGl0eS1uYXYtcmlnaHQgLmRyb3Bkb3duIC5kcm9wZG93bi1saXN0LXdyYXBwZXIgLmRyb3Bkb3duLWxpc3QgdWwge1xuICAgIHBhZGRpbmctaW5saW5lLXN0YXJ0OiAwO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLmNvbnRlbnQtd3JhcHBlciAudXRpbGl0eS1uYXYtcmlnaHQgLmRyb3Bkb3duIC5kcm9wZG93bi1saXN0LXdyYXBwZXIgLmRyb3Bkb3duLWxpc3QgLm9zYi1uYXYtaXRlbSB7XG4gICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICBib3JkZXItcmFkaXVzOiA0cHg7XG4gICAgZGlzcGxheTogZmxleDtcbiAgICBmb250LXdlaWdodDogNjAwO1xuICAgIG1hcmdpbi1ib3R0b206IDAuNXJlbTtcbiAgICBwYWRkaW5nOiAwLjI1cmVtIDAuMjVyZW0gMC4yNXJlbSAxLjVyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC51dGlsaXR5LW5hdi1yaWdodCAuZHJvcGRvd24gLmRyb3Bkb3duLWxpc3Qtd3JhcHBlciAuZHJvcGRvd24tbGlzdCAub3NiLW5hdi1pdGVtOmFjdGl2ZSB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogI2ViZjJmZjtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC5jb250ZW50LXdyYXBwZXIgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biAuZHJvcGRvd24tbGlzdC13cmFwcGVyIC5kcm9wZG93bi1saXN0IC5vc2ItbmF2LWl0ZW06Zm9jdXMge1xuICAgIGJhY2tncm91bmQtY29sb3I6ICNlYmYyZmY7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC51dGlsaXR5LW5hdi1yaWdodCAuZHJvcGRvd24gLmRyb3Bkb3duLWxpc3Qtd3JhcHBlciAuZHJvcGRvd24tbGlzdCAub3NiLW5hdi1pdGVtOmhvdmVyIHtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZWJmMmZmO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLmNvbnRlbnQtd3JhcHBlciAudXRpbGl0eS1uYXYtcmlnaHQgLmRyb3Bkb3duIC5kcm9wZG93bi1saXN0LXdyYXBwZXIgLmRyb3Bkb3duLWxpc3QgLm9zYi1uYXYtaXRlbSAubGFuZ3VhZ2UtZW50cnktbG9uZy10ZXh0IHtcbiAgICBjb2xvcjogdmFyKC0tbmV1dHJhbC0yKTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC5jb250ZW50LXdyYXBwZXIgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biAuZHJvcGRvd24tbGlzdC13cmFwcGVyIC5kcm9wZG93bi1saXN0IC5vc2ItbmF2LWl0ZW0gLmxhbmd1YWdlLWVudHJ5LWxvbmctdGV4dDphY3RpdmUge1xuICAgIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTIpO1xuICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC5jb250ZW50LXdyYXBwZXIgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biAuZHJvcGRvd24tbGlzdC13cmFwcGVyIC5kcm9wZG93bi1saXN0IC5vc2ItbmF2LWl0ZW0gLmxhbmd1YWdlLWVudHJ5LWxvbmctdGV4dDp2aXNpdGVkIHtcbiAgICBjb2xvcjogdmFyKC0tbmV1dHJhbC0yKTtcbiAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC51dGlsaXR5LW5hdi1yaWdodCAuZHJvcGRvd24gLmRyb3Bkb3duLWxpc3Qtd3JhcHBlciAuZHJvcGRvd24tbGlzdCAub3NiLW5hdi1pdGVtIC5sYW5ndWFnZS1lbnRyeS1sb25nLXRleHQ6Zm9jdXMge1xuICAgIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTIpO1xuICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC5jb250ZW50LXdyYXBwZXIgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biAuZHJvcGRvd24tbGlzdC13cmFwcGVyIC5kcm9wZG93bi1saXN0IC5vc2ItbmF2LWl0ZW0gLmxhbmd1YWdlLWVudHJ5LWxvbmctdGV4dDpob3ZlciB7XG4gICAgY29sb3I6IHZhcigtLW5ldXRyYWwtMik7XG4gICAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLmNvbnRlbnQtd3JhcHBlciAudXRpbGl0eS1uYXYtcmlnaHQgLmRyb3Bkb3duIC5kcm9wZG93bi1saXN0LXdyYXBwZXIgLmRyb3Bkb3duLWxpc3QgLm9zYi1uYXYtaXRlbS5zZWxlY3RlZCB7XG4gICAgcGFkZGluZy1sZWZ0OiAwLjQzNzVyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC51dGlsaXR5LW5hdi1yaWdodCAuZHJvcGRvd24gLmRyb3Bkb3duLWxpc3Qtd3JhcHBlciAuZHJvcGRvd24tbGlzdCAub3NiLW5hdi1pdGVtLnNlbGVjdGVkIC5sYW5ndWFnZS1lbnRyeS1sb25nLXRleHQge1xuICAgIGNvbG9yOiAjMDA0YWQ3O1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLmNvbnRlbnQtd3JhcHBlciAudXRpbGl0eS1uYXYtcmlnaHQgLmRyb3Bkb3duIC5kcm9wZG93bi1saXN0LXdyYXBwZXIgLmRyb3Bkb3duLWxpc3QgLnNlbGVjdGVkLm9zYi1uYXYtaXRlbTpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IHVybChcImRhdGE6aW1hZ2Uvc3ZnK3htbDtjaGFyc2V0PVVTLUFTQ0lJLCUzQ3N2ZyUyMHdpZHRoJTNEJTIyMTIlMjIlMjBoZWlnaHQlM0QlMjI5JTIyJTIwdmlld0JveCUzRCUyMjAlMjAwJTIwMTIlMjA5JTIyJTIwZmlsbCUzRCUyMm5vbmUlMjIlMjB4bWxucyUzRCUyMmh0dHAlM0EvL3d3dy53My5vcmcvMjAwMC9zdmclMjIlM0UlMEElM0NwYXRoJTIwZmlsbC1ydWxlJTNEJTIyZXZlbm9kZCUyMiUyMGNsaXAtcnVsZSUzRCUyMmV2ZW5vZGQlMjIlMjBkJTNEJTIyTTkuNjI2MjMlMjAwLjk1ODkwOUMxMC4wMTY4JTIwMC41NjgzODUlMjAxMC42NDk5JTIwMC41NjgzODUlMjAxMS4wNDA0JTIwMC45NTg5MDlDMTEuNDMxJTIwMS4zNDk0MyUyMDExLjQzMSUyMDEuOTgyNiUyMDExLjA0MDQlMjAyLjM3MzEyTDUuMDQxMjclMjA4LjM3MjI5QzUuMDQwOTklMjA4LjM3MjU3JTIwNS4wNDA3MiUyMDguMzcyODUlMjA1LjA0MDQ0JTIwOC4zNzMxMkM0LjY0OTkyJTIwOC43NjM2NSUyMDQuMDE2NzUlMjA4Ljc2MzY1JTIwMy42MjYyMyUyMDguMzczMTJMMC4yOTI4OTMlMjA1LjAzOTc5Qy0wLjA5NzYzMTElMjA0LjY0OTI3JTIwLTAuMDk3NjMxMSUyMDQuMDE2MSUyMDAuMjkyODkzJTIwMy42MjU1OEMwLjY4MzQxNyUyMDMuMjM1MDUlMjAxLjMxNjU4JTIwMy4yMzUwNSUyMDEuNzA3MTElMjAzLjYyNTU4TDQuMzMzMzMlMjA2LjI1MThMOS42MjYyMyUyMDAuOTU4OTA5WiUyMiUyMGZpbGwlM0QlMjIlMjMwMDRBRDclMjIvJTNFJTBBJTNDL3N2ZyUzRSUwQVwiKTtcbiAgICBtYXJnaW4tcmlnaHQ6IDAuMzEyNXJlbTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC5jb250ZW50LXdyYXBwZXIgLnV0aWxpdHktbmF2LXJpZ2h0IC5kcm9wZG93biAuZHJvcGRvd24tbGlzdC13cmFwcGVyLmxpc3Qtb3BlbiB7XG4gICAgZGlzcGxheTogYmxvY2s7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC51dGlsaXR5LW5hdi1yaWdodCAuc2VhcmNoLWJ1dHRvbiB7XG4gICAgYm9yZGVyLXJhZGl1czogNHB4O1xuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICBtYXJnaW4tbGVmdDogMC41cmVtO1xuICAgIG9wYWNpdHk6IDAuNztcbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgdHJhbnNpdGlvbi1kdXJhdGlvbjogMC4ycywgMC4ycywgMC4ycztcbiAgICB0cmFuc2l0aW9uLXByb3BlcnR5OiBvcGFjaXR5LCBiYWNrZ3JvdW5kLWNvbG9yLCBzdHJva2U7XG4gICAgdHJhbnNpdGlvbi10aW1pbmctZnVuY3Rpb246IGVhc2UsIGVhc2UsIGVhc2U7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC51dGlsaXR5LW5hdiAuY29udGVudC13cmFwcGVyIC51dGlsaXR5LW5hdi1yaWdodCAuc2VhcmNoLWJ1dHRvbiBzdmcge1xuICAgIGhlaWdodDogMi41cmVtO1xuICAgIHN0cm9rZTogdmFyKC0tYWNjZW50LTEwKTtcbiAgICB0cmFuc2l0aW9uLWR1cmF0aW9uOiAwLjJzO1xuICAgIHRyYW5zaXRpb24tcHJvcGVydHk6IHN0cm9rZTtcbiAgICB0cmFuc2l0aW9uLXRpbWluZy1mdW5jdGlvbjogZWFzZTtcbiAgICB3aWR0aDogMi41cmVtO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYgLmNvbnRlbnQtd3JhcHBlciAudXRpbGl0eS1uYXYtcmlnaHQgLnNlYXJjaC1idXR0b246aG92ZXIge1xuICAgIGJhY2tncm91bmQtY29sb3I6ICNlYmYyZmY7XG4gICAgb3BhY2l0eTogMTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnV0aWxpdHktbmF2IC5jb250ZW50LXdyYXBwZXIgLnV0aWxpdHktbmF2LXJpZ2h0IC5zZWFyY2gtYnV0dG9uOmhvdmVyIHN2ZyB7XG4gICAgc3Ryb2tlOiB2YXIoLS1hY3Rpb24tZGVmYXVsdC1hY3RpdmUpO1xuICB9XG59XG5AbWVkaWEgKG1heC13aWR0aDogNTk5cHgpIHtcbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiB7XG4gICAgYm9yZGVyOiBub25lO1xuICAgIGhlaWdodDogMDtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIge1xuICAgIHBhZGRpbmc6IDAgMS41cmVtO1xuICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLmxpZmVyYXktbG9nbyB7XG4gICAgZGlzcGxheTogbm9uZTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLm5hdi1pdGVtcy13cmFwcGVyIHtcbiAgICBhbGlnbi1pdGVtczogY2VudGVyO1xuICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICAgIGhlaWdodDogMDtcbiAgICBsZWZ0OiAwO1xuICAgIG9wYWNpdHk6IDA7XG4gICAgcGFkZGluZy1ib3R0b206IDguNXJlbTtcbiAgICBwYWRkaW5nLXRvcDogMDtcbiAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgdG9wOiAwO1xuICAgIHRyYW5zaXRpb246IGFsbCAwLjVzIGN1YmljLWJlemllcigwLjE5LCAxLCAwLjIyLCAxKTtcbiAgICB2aXNpYmlsaXR5OiBoaWRkZW47XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlci5tZW51LW9wZW4ge1xuICAgIGJhY2tncm91bmQtY29sb3I6IHZhcigtLXdoaXRlKTtcbiAgICBoZWlnaHQ6IDEwMHZoO1xuICAgIG9wYWNpdHk6IDE7XG4gICAgb3ZlcmZsb3cteDogaGlkZGVuO1xuICAgIHRvcDogMDtcbiAgICB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoMCk7XG4gICAgdmlzaWJpbGl0eTogdmlzaWJsZTtcbiAgICB6LWluZGV4OiAyO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAucHJpbWFyeS1uYXYgLmNvbnRlbnQtd3JhcHBlciAubmF2LWl0ZW1zLXdyYXBwZXIubWVudS1vcGVuOjphZnRlciB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0td2hpdGUpO1xuICAgIGNvbnRlbnQ6IFwiXCI7XG4gICAgaGVpZ2h0OiAxMDB2aDtcbiAgICB3aWR0aDogMTAwdnc7XG4gICAgei1pbmRleDogLTM7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAuYWR0LW5hdmlnYXRpb24ge1xuICAgIGJhY2tncm91bmQ6IHZhcigtLXdoaXRlKTtcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgIGZsZXgtZGlyZWN0aW9uOiBjb2x1bW47XG4gICAgb3ZlcmZsb3c6IHZpc2libGU7XG4gICAgd2lkdGg6IDEwMHZ3O1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAucHJpbWFyeS1uYXYgLmNvbnRlbnQtd3JhcHBlciAubmF2LWl0ZW1zLXdyYXBwZXIgLmFkdC1uYXZpZ2F0aW9uIC5hZHQtbmF2LXRleHQge1xuICAgIHBhZGRpbmctYm90dG9tOiAwLjg3NXJlbTtcbiAgICBwYWRkaW5nLXRvcDogMC44NzVyZW07XG4gICAgcG9zaXRpb246IHN0aWNreTtcbiAgICBwb3NpdGlvbjogLXdlYmtpdC1zdGlja3k7XG4gICAgdG9wOiAwO1xuICAgIHdpZHRoOiAxMDAlO1xuICAgIHotaW5kZXg6IDM7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAuYWR0LW5hdmlnYXRpb24gLmFkdC1uYXYtdGV4dCAuYWR0LW5hdi10aXRsZSB7XG4gICAgcGFkZGluZy1sZWZ0OiAxLjVyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAuYWR0LW5hdmlnYXRpb24gLmFkdC1hbmdsZS1kb3duLXN2ZyB7XG4gICAgcG9zaXRpb246IGFic29sdXRlO1xuICAgIHJpZ2h0OiAxLjVyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAudW5kZXJsaW5lLWNvbnRhaW5lciB7XG4gICAgZGlzcGxheTogYmxvY2s7XG4gICAgcGFkZGluZzogMC4zNzVyZW0gMS41cmVtIDAgMS41cmVtO1xuICAgIHdpZHRoOiAxMDAlO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAucHJpbWFyeS1uYXYgLmNvbnRlbnQtd3JhcHBlciAubmF2LWl0ZW1zLXdyYXBwZXIgLnVuZGVybGluZS1jb250YWluZXIgLnVuZGVybGluZSB7XG4gICAgYm9yZGVyOiAxcHggc29saWQgdmFyKC0tbmV1dHJhbC03KTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLm5hdi1pdGVtcy13cmFwcGVyIC5jb250YWN0LXNhbGVzLWNvbnRhaW5lciB7XG4gICAgZGlzcGxheTogZmxleDtcbiAgICBwYWRkaW5nOiAwIDEuNXJlbSAxMHJlbTtcbiAgICB3aWR0aDogMTAwJTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLm5hdi1pdGVtcy13cmFwcGVyIC5jb250YWN0LXNhbGVzLWNvbnRhaW5lciAuY29udGFjdC1zYWxlcyB7XG4gICAgYm94LXNoYWRvdzogMHB4IDEuMXB4IDQuMDVweCAtMC42NnB4IHJnYmEoMCwgMCwgMCwgMC4xNCksIDBweCAzcHggNC41cHggMC4zcHggcmdiYSgwLCAwLCAwLCAwLjAzNiksIDBweCAyLjlweCA2cHggMC4ycHggcmdiYSgwLCAwLCAwLCAwLjA2KTtcbiAgICBtYXJnaW46IDA7XG4gICAgdGV4dC1hbGlnbjogY2VudGVyO1xuICAgIHdpZHRoOiAxMDAlO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAucHJpbWFyeS1uYXYgLmNvbnRlbnQtd3JhcHBlciAubmF2LWl0ZW1zLXdyYXBwZXIgLnV0aWxpdHktbmF2LWxlZnQge1xuICAgIGJhY2tncm91bmQtY29sb3I6IHZhcigtLXdoaXRlKTtcbiAgICBkaXNwbGF5OiBibG9jaztcbiAgICBwYWRkaW5nOiAxLjVyZW0gMS41cmVtIDJyZW07XG4gICAgd2lkdGg6IDEwMCU7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAudXRpbGl0eS1uYXYtbGVmdCAuaW5mby1mb3Ige1xuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgZm9udC13ZWlnaHQ6IDYwMDtcbiAgICBqdXN0aWZ5LWNvbnRlbnQ6IHNwYWNlLWJldHdlZW47XG4gICAgd2lkdGg6IDEwMCU7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAudXRpbGl0eS1uYXYtbGVmdCAuaW5mby1mb3IgPiBhIHtcbiAgICBjb2xvcjogdmFyKC0tbmV1dHJhbC0zKTtcbiAgICBmb250LXNpemU6IDFyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAubmF2YmFyLW5hdiB7XG4gICAgYmFja2dyb3VuZDogdmFyKC0td2hpdGUpO1xuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgZmxleC1kaXJlY3Rpb246IGNvbHVtbjtcbiAgICB3aWR0aDogMTAwdnc7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAubmF2YmFyLW5hdiAubmF2LWxpbmsge1xuICAgIHBhZGRpbmctYm90dG9tOiAwLjg3NXJlbTtcbiAgICBwYWRkaW5nLXRvcDogMC44NzVyZW07XG4gICAgd2lkdGg6IDEwMCU7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAubmF2YmFyLW5hdiAubmF2LWxpbmsgPiBzcGFuIHtcbiAgICBwYWRkaW5nLWxlZnQ6IDFyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAubmF2YmFyLW5hdiAubGZyLW5hdi1jaGlsZC10b2dnbGUge1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICByaWdodDogMS41cmVtO1xuICB9XG59XG5AbWVkaWEgKG1heC13aWR0aDogNTk5cHgpIHtcbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5tb2JpbGUtYnV0dG9ucyB7XG4gICAgYm90dG9tOiAwLjc1cmVtO1xuICAgIHBvc2l0aW9uOiBmaXhlZDtcbiAgICByaWdodDogNTAlO1xuICAgIHRyYW5zZm9ybTogdHJhbnNsYXRlKDUwJSwgMCk7XG4gICAgei1pbmRleDogMztcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLm1vYmlsZS1idXR0b25zIC5jb250YWN0LXNhbGVzIHtcbiAgICBkaXNwbGF5OiBub25lO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAubW9iaWxlLWJ1dHRvbnMgLm1vYmlsZS1tZW51IHtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS13aGl0ZSk7XG4gICAgYm9yZGVyOiAxcHggc29saWQgdmFyKC0tYWN0aW9uLWRlZmF1bHQpO1xuICAgIGJvcmRlci1yYWRpdXM6IDEuNXJlbTtcbiAgICBib3gtc2hhZG93OiAwcHggMS4xcHggNC4wNXB4IC0wLjY2cHggcmdiYSgwLCAwLCAwLCAwLjE0KSwgMHB4IDNweCA0LjVweCAwLjNweCByZ2JhKDAsIDAsIDAsIDAuMDM2KSwgMHB4IDIuOXB4IDZweCAwLjJweCByZ2JhKDAsIDAsIDAsIDAuMDYpO1xuICAgIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdCk7XG4gICAgZGlzcGxheTogYmxvY2s7XG4gICAgZm9udC1zaXplOiAxLjEyNXJlbTtcbiAgICBmb250LXdlaWdodDogNjAwO1xuICAgIHBhZGRpbmc6IDAuNXJlbSAxcmVtO1xuICAgIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gICAgd2lkdGg6IDcuNXJlbTtcbiAgfVxufVxuQG1lZGlhIChtaW4td2lkdGg6IDYwMHB4KSBhbmQgKG1heC13aWR0aDogMTE5OXB4KSB7XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudSB7XG4gICAgYm94LXNoYWRvdzogbm9uZTtcbiAgICBncmlkLXJvdy1nYXA6IDA7XG4gICAgaGVpZ2h0OiBhdXRvO1xuICAgIG1hcmdpbjogMDtcbiAgICBtYXgtaGVpZ2h0OiAwO1xuICAgIG9wYWNpdHk6IDE7XG4gICAgcGFkZGluZzogMDtcbiAgICBwb3NpdGlvbjogc3RhdGljO1xuICAgIHRyYW5zZm9ybTogbm9uZTtcbiAgICB0cmFuc2l0aW9uOiBtYXgtaGVpZ2h0IDAuM3MgY3ViaWMtYmV6aWVyKDAuMjMsIDEsIDAuMzIsIDEpO1xuICAgIHZpc2liaWxpdHk6IHZpc2libGU7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51IC5hZHQtc3VibWVudS1vdXRlci13cmFwcGVyIC5hZHQtc3VibWVudS1pbm5lci13cmFwcGVyIHtcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgIGZsZXgtZGlyZWN0aW9uOiBjb2x1bW47XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24ge1xuICAgIGdyaWQtdGVtcGxhdGUtcm93czogbm9uZTtcbiAgICBwYWRkaW5nOiAycmVtO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uIC5hZHQtc3VibWVudS1pdGVtLWNvbnRlbnQuZ3JpZC1jb2x1bW4tc3Bhbi0xLCAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbiAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50LmdyaWQtY29sdW1uLXNwYW4tMiwgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24gLmFkdC1zdWJtZW51LWl0ZW0tY29udGVudC5ncmlkLWNvbHVtbi1zcGFuLTMsIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uIC5hZHQtc3VibWVudS1pdGVtLWNvbnRlbnQuZ3JpZC1jb2x1bW4tc3Bhbi00LCAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbiAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50LmdyaWQtY29sdW1uLXNwYW4tNSwgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24gLmFkdC1zdWJtZW51LWl0ZW0tY29udGVudC5ncmlkLWNvbHVtbi1zcGFuLTYsIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uIC5hZHQtc3VibWVudS1pdGVtLWNvbnRlbnQuZ3JpZC1jb2x1bW4tc3Bhbi03LCAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbiAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50LmdyaWQtY29sdW1uLXNwYW4tOCwgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24gLmFkdC1zdWJtZW51LWl0ZW0tY29udGVudC5ncmlkLWNvbHVtbi1zcGFuLTksIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uIC5hZHQtc3VibWVudS1pdGVtLWNvbnRlbnQuZ3JpZC1jb2x1bW4tc3Bhbi0xMCwgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24gLmFkdC1zdWJtZW51LWl0ZW0tY29udGVudC5ncmlkLWNvbHVtbi1zcGFuLTExLCAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbiAuYWR0LXN1Ym1lbnUtaXRlbS1jb250ZW50LmdyaWQtY29sdW1uLXNwYW4tMTIge1xuICAgIGdyaWQtY29sdW1uLXN0YXJ0OiBzcGFuIDE7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24uXzMtc2VjdGlvbi1zcGFuLCAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fNC1zZWN0aW9uLXNwYW4sIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLl81LXNlY3Rpb24tc3BhbiwgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24uXzYtc2VjdGlvbi1zcGFuLCAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fNy1zZWN0aW9uLXNwYW4sIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLl84LXNlY3Rpb24tc3BhbiwgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24uXzktc2VjdGlvbi1zcGFuLCAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fMTAtc2VjdGlvbi1zcGFuLCAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fMTEtc2VjdGlvbi1zcGFuLCAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fMTItc2VjdGlvbi1zcGFuIHtcbiAgICAtbXMtZ3JpZC1jb2x1bW4tc3BhbjogMjtcbiAgICBncmlkLWNvbHVtbi1zdGFydDogc3BhbiAyO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLl8zLXNlY3Rpb24tc3BhbiAuYWR0LXN1Ym1lbnUtaGVhZGVyLCAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fNC1zZWN0aW9uLXNwYW4gLmFkdC1zdWJtZW51LWhlYWRlciwgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24uXzUtc2VjdGlvbi1zcGFuIC5hZHQtc3VibWVudS1oZWFkZXIsIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLl82LXNlY3Rpb24tc3BhbiAuYWR0LXN1Ym1lbnUtaGVhZGVyLCAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fNy1zZWN0aW9uLXNwYW4gLmFkdC1zdWJtZW51LWhlYWRlciwgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24uXzgtc2VjdGlvbi1zcGFuIC5hZHQtc3VibWVudS1oZWFkZXIsIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLl85LXNlY3Rpb24tc3BhbiAuYWR0LXN1Ym1lbnUtaGVhZGVyLCAuZi1uYXZpZ2F0aW9uLXByaW1hcnkubmF2LXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LXN1Ym1lbnUtc2VjdGlvbi5fMTAtc2VjdGlvbi1zcGFuIC5hZHQtc3VibWVudS1oZWFkZXIsIC5mLW5hdmlnYXRpb24tcHJpbWFyeS5uYXYtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtc3VibWVudS1zZWN0aW9uLl8xMS1zZWN0aW9uLXNwYW4gLmFkdC1zdWJtZW51LWhlYWRlciwgLmYtbmF2aWdhdGlvbi1wcmltYXJ5Lm5hdi13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51LXNlY3Rpb24uXzEyLXNlY3Rpb24tc3BhbiAuYWR0LXN1Ym1lbnUtaGVhZGVyIHtcbiAgICAtbXMtZ3JpZC1jb2x1bW4tc3BhbjogMjtcbiAgICBncmlkLWNvbHVtbi1zdGFydDogc3BhbiAyO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAucHJpbWFyeS1uYXYge1xuICAgIHBhZGRpbmc6IDA7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIHtcbiAgICBwYWRkaW5nLWxlZnQ6IDEuNXJlbTtcbiAgICBwYWRkaW5nLXJpZ2h0OiAycmVtO1xuICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLmxpZmVyYXktbG9nbyB7XG4gICAgcGFkZGluZy1sZWZ0OiAwLjVyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5saWZlcmF5LWxvZ28gc3ZnIHtcbiAgICBoZWlnaHQ6IDNyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciB7XG4gICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICBoZWlnaHQ6IDA7XG4gICAgbGVmdDogMDtcbiAgICBvcGFjaXR5OiAwO1xuICAgIHBhZGRpbmctYm90dG9tOiAwO1xuICAgIHBhZGRpbmctdG9wOiAwO1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICB0b3A6IDA7XG4gICAgdHJhbnNpdGlvbjogYWxsIDAuNXMgY3ViaWMtYmV6aWVyKDAuMTksIDEsIDAuMjIsIDEpO1xuICAgIHZpc2liaWxpdHk6IGhpZGRlbjtcbiAgICB6LWluZGV4OiAtMTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLm5hdi1pdGVtcy13cmFwcGVyLm1lbnUtb3BlbiB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0td2hpdGUpO1xuICAgIGhlaWdodDogMTAwdmg7XG4gICAgb3BhY2l0eTogMTtcbiAgICBvdmVyZmxvdzogYXV0bztcbiAgICB0b3A6IDRyZW07XG4gICAgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKDApO1xuICAgIHZpc2liaWxpdHk6IHZpc2libGU7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAuY29udGFjdC1zYWxlcy1jb250YWluZXIsXG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAucHJpbWFyeS1uYXYgLmNvbnRlbnQtd3JhcHBlciAubmF2LWl0ZW1zLXdyYXBwZXIgLnV0aWxpdHktbmF2LWxlZnQge1xuICAgIGRpc3BsYXk6IG5vbmU7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAuYWR0LW5hdmlnYXRpb24ge1xuICAgIGJhY2tncm91bmQ6IHZhcigtLXdoaXRlKTtcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgIGZsZXgtZGlyZWN0aW9uOiBjb2x1bW47XG4gICAgaGVpZ2h0OiBjYWxjKDEwMHZoIC0gMTIwcHggLSA0cmVtKTtcbiAgICBvdmVyZmxvdzogYXV0bztcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLm5hdi1pdGVtcy13cmFwcGVyIC5hZHQtbmF2aWdhdGlvbiAuYWR0LW5hdi10ZXh0IHtcbiAgICBwYWRkaW5nOiAwLjg3NXJlbSAxcmVtO1xuICAgIHBvc2l0aW9uOiBzdGlja3k7XG4gICAgcG9zaXRpb246IC13ZWJraXQtc3RpY2t5O1xuICAgIHRvcDogMDtcbiAgICB3aWR0aDogMTAwJTtcbiAgICB6LWluZGV4OiAzO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAucHJpbWFyeS1uYXYgLmNvbnRlbnQtd3JhcHBlciAubmF2LWl0ZW1zLXdyYXBwZXIgLmFkdC1uYXZpZ2F0aW9uIC5hZHQtbmF2LXRleHQgLmFkdC1uYXYtdGl0bGUge1xuICAgIHBhZGRpbmctbGVmdDogMXJlbTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLm5hdi1pdGVtcy13cmFwcGVyIC5hZHQtbmF2aWdhdGlvbiAuYWR0LWFuZ2xlLWRvd24tc3ZnIHtcbiAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgcmlnaHQ6IDEuNXJlbTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLm1vYmlsZS1idXR0b25zIHtcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgIHBhZGRpbmctcmlnaHQ6IDEuNXJlbTtcbiAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgcmlnaHQ6IDA7XG4gICAgei1pbmRleDogMTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLm1vYmlsZS1idXR0b25zIC50YWJsZXQge1xuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICBtYXJnaW4tbGVmdDogMDtcbiAgICBtYXJnaW4tcmlnaHQ6IDFyZW07XG4gICAgdG9wOiBhdXRvO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAubW9iaWxlLWJ1dHRvbnMgLm1vYmlsZS1tZW51IHtcbiAgICBib3JkZXI6IDFweCBzb2xpZCB2YXIoLS1hY3Rpb24tZGVmYXVsdCk7XG4gICAgYm9yZGVyLXJhZGl1czogNHB4O1xuICAgIGNvbG9yOiB2YXIoLS1hY3Rpb24tZGVmYXVsdCk7XG4gICAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICAgIGZvbnQtc2l6ZTogMXJlbTtcbiAgICBmb250LXdlaWdodDogNjAwO1xuICAgIGxpbmUtaGVpZ2h0OiAyNHB4O1xuICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgICB6LWluZGV4OiAxO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAubW9iaWxlLWJ1dHRvbnMgLm1vYmlsZS1tZW51IC5idXR0b24tdGV4dC1jbG9zZSB7XG4gICAgcGFkZGluZzogMC41cmVtIDFyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5tb2JpbGUtYnV0dG9ucyAubW9iaWxlLW1lbnUgLmJ1dHRvbi10ZXh0LW1lbnUge1xuICAgIHBhZGRpbmc6IDAuNXJlbSAxcmVtO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAudXRpbGl0eS1uYXYge1xuICAgIHBhZGRpbmc6IDAgMnJlbTtcbiAgfVxufVxuQG1lZGlhIChtaW4td2lkdGg6IDEyMDBweCkge1xuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLm5hdi5zaG93LWJvcmRlciB7XG4gICAgYm9yZGVyLWJvdHRvbTogMXB4IHNvbGlkIHZhcigtLW5ldXRyYWwtOCk7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5uYXYgLnV0aWxpdHktbmF2IC5jb250ZW50LXdyYXBwZXIge1xuICAgIG1hcmdpbjogMCA0cmVtO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAucHJpbWFyeS1uYXYge1xuICAgIGJvcmRlci1ib3R0b206IDFweCBzb2xpZCB0cmFuc3BhcmVudDtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIge1xuICAgIG1hcmdpbjogMCA0cmVtO1xuICAgIHBhZGRpbmc6IDA7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5saWZlcmF5LWxvZ28gc3ZnIHtcbiAgICBoZWlnaHQ6IDMuMzdyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciB7XG4gICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgIHBhZGRpbmc6IDA7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAuYWR0LW5hdi1pdGVtLmRyb3Bkb3duLW9wZW4gLmFkdC1uYXYtdGV4dDo6YWZ0ZXIge1xuICAgIGxlZnQ6IDA7XG4gICAgd2lkdGg6IDEwMCU7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtbmF2LXRleHQge1xuICAgIGJvcmRlci1yYWRpdXM6IDRweDtcbiAgICBwYWRkaW5nOiAwO1xuICB9XG4gIC5mLW5hdmlnYXRpb24tcHJpbWFyeSAucHJpbWFyeS1uYXYgLmNvbnRlbnQtd3JhcHBlciAubmF2LWl0ZW1zLXdyYXBwZXIgLmFkdC1uYXYtaXRlbSAuYWR0LW5hdi10ZXh0IC5hZHQtbmF2LXRpdGxlIHtcbiAgICBjdXJzb3I6IHBvaW50ZXI7XG4gICAgZm9udC1zaXplOiAxLjEyNXJlbTtcbiAgICBwYWRkaW5nOiAwLjg3NXJlbSAxLjEyNXJlbSAwLjY4OHJlbTtcbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAuYWR0LW5hdi1pdGVtIC5hZHQtbmF2LXRleHQgLmFkdC1uYXYtdGl0bGUgLmFkdC1hbmdsZS1kb3duLXN2ZyB7XG4gICAgZGlzcGxheTogbm9uZTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLm5hdi1pdGVtcy13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1uYXYtdGV4dDo6YWZ0ZXIge1xuICAgIGJhY2tncm91bmQ6ICMwMDRhZDc7XG4gICAgYm90dG9tOiAtNXB4O1xuICAgIGNvbnRlbnQ6IFwiXCI7XG4gICAgaGVpZ2h0OiAzcHg7XG4gICAgbGVmdDogNTAlO1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICB0cmFuc2l0aW9uOiBsZWZ0IGVhc2UtaW4gMC4zcywgd2lkdGggZWFzZS1pbiAwLjNzO1xuICAgIHdpZHRoOiAwJTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLnByaW1hcnktbmF2IC5jb250ZW50LXdyYXBwZXIgLm5hdi1pdGVtcy13cmFwcGVyIC5hZHQtbmF2LWl0ZW0gLmFkdC1zdWJtZW51IHtcbiAgICBib3JkZXItcmFkaXVzOiAwIDAgMC41cmVtIDAuNXJlbTtcbiAgICBib3gtc2hhZG93OiAwcHggNy40cHggMTEuNHB4IC03LjU5cHggcmdiYSgwLCAwLCAwLCAwLjE0KSwgMHB4IDI0cHggMzZweCAzLjQ1cHggcmdiYSgwLCAwLCAwLCAwLjA3OCksIDBweCA5LjJweCA0OHB4IDguNnB4IHJnYmEoMCwgMCwgMCwgMC4wNik7XG4gICAgcGFkZGluZy1ib3R0b206IDFyZW07XG4gIH1cbiAgLmYtbmF2aWdhdGlvbi1wcmltYXJ5IC5wcmltYXJ5LW5hdiAuY29udGVudC13cmFwcGVyIC5uYXYtaXRlbXMtd3JhcHBlciAudXRpbGl0eS1uYXYtbGVmdCB7XG4gICAgZGlzcGxheTogbm9uZTtcbiAgfVxuICAuZi1uYXZpZ2F0aW9uLXByaW1hcnkgLm1vYmlsZS1idXR0b25zIHtcbiAgICBkaXNwbGF5OiBub25lO1xuICB9XG59XG5cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLWFjY2VudC0xMCk7XG4gIGNvbG9yOiB2YXIoLS13aGl0ZSk7XG4gIHBhZGRpbmc6IDFlbTtcbn1cbkBtZWRpYSBzY3JlZW4gYW5kIChtaW4td2lkdGg6IDc2N3B4KSB7XG4gICNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciB7XG4gICAgcGFkZGluZzogMCAzZW07XG4gIH1cbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAubWF4LW5hdiB7XG4gIG1hcmdpbjogMCBhdXRvO1xuICBtYXgtd2lkdGg6IDEyNDBweDtcbiAgcGFkZGluZzogM2VtIDAgIWltcG9ydGFudDtcbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciB1bCB7XG4gIG1hcmdpbjogMDtcbiAgcGFkZGluZzogMDtcbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciBsaSB7XG4gIGxpbmUtaGVpZ2h0OiAyMHB4O1xuICBsaXN0LXN0eWxlOiBub25lO1xuICBtYXJnaW46IDA7XG59XG4jZm9vdGVyLmYtbmF2aWdhdGlvbi1mb290ZXIgaDQge1xuICBjb2xvcjogdmFyKC0td2hpdGUpO1xuICBsaW5lLWhlaWdodDogMS41ZW07XG4gIG1hcmdpbjogMDtcbiAgcGFkZGluZzogMS41ZW0gMDtcbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciBhIHtcbiAgZGlzcGxheTogYmxvY2s7XG59XG4jZm9vdGVyLmYtbmF2aWdhdGlvbi1mb290ZXIgYTpob3ZlciB7XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZm9vdGVyLWNvbnRlbnQge1xuICAtd2Via2l0LWJveC1kaXJlY3Rpb246IG5vcm1hbDtcbiAgLXdlYmtpdC1ib3gtb3JpZW50OiB2ZXJ0aWNhbDtcbiAgLW1zLWZsZXgtZGlyZWN0aW9uOiBjb2x1bW47XG4gIGZsZXgtZGlyZWN0aW9uOiBjb2x1bW47XG4gIGZsZXgtd3JhcDogbm93cmFwO1xuICBwYWRkaW5nOiAxZW0gMDtcbn1cbkBtZWRpYSBzY3JlZW4gYW5kIChtaW4td2lkdGg6IDc2N3B4KSB7XG4gICNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZm9vdGVyLWNvbnRlbnQge1xuICAgIGZsZXgtZGlyZWN0aW9uOiByb3c7XG4gIH1cbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZm9vdGVyLWNvbnRlbnQgLmZvb3Rlci1uYXZpZ2F0aW9uIHtcbiAgLXdlYmtpdC1ib3gtZmxleDogNTtcbiAgZmxleDogNTtcbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZm9vdGVyLWNvbnRlbnQgLmZvb3Rlci1uYXZpZ2F0aW9uIC5sYW5ndWFnZS13cmFwcGVyIHtcbiAgYm94LXNpemluZzogYm9yZGVyLWJveDtcbiAgbWFyZ2luOiAwO1xuICBwYWRkaW5nLWJvdHRvbTogMS41ZW07XG4gIC13ZWJraXQtdXNlci1zZWxlY3Q6IG5vbmU7XG4gIC1tb3otdXNlci1zZWxlY3Q6IG5vbmU7XG4gIC1tcy11c2VyLXNlbGVjdDogbm9uZTtcbiAgdXNlci1zZWxlY3Q6IG5vbmU7XG59XG5AbWVkaWEgc2NyZWVuIGFuZCAobWluLXdpZHRoOiA3NjdweCkge1xuICAjZm9vdGVyLmYtbmF2aWdhdGlvbi1mb290ZXIgLmZvb3Rlci1jb250ZW50IC5mb290ZXItbmF2aWdhdGlvbiAubGFuZ3VhZ2Utd3JhcHBlciB7XG4gICAgbWFyZ2luLWxlZnQ6IC0yZW07XG4gIH1cbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZm9vdGVyLWNvbnRlbnQgLmZvb3Rlci1uYXZpZ2F0aW9uIC5sYW5ndWFnZS13cmFwcGVyIC5sYW5ndWFnZXMgLnNlbGVjdGVkIHtcbiAgZGlzcGxheTogbm9uZTtcbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZm9vdGVyLWNvbnRlbnQgLmZvb3Rlci1uYXZpZ2F0aW9uIC5sYW5ndWFnZS13cmFwcGVyLmNsYXNzLXRvZ2dsZS1hY3RpdmUgLmRyb3Bkb3duLWNvbnRlbnQge1xuICBoZWlnaHQ6IGF1dG87XG4gIG9wYWNpdHk6IDE7XG4gIG92ZXJmbG93OiB2aXNpYmxlO1xuICBwYWRkaW5nOiAwLjVlbTtcbiAgdmlzaWJpbGl0eTogdmlzaWJsZTtcbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZm9vdGVyLWNvbnRlbnQgLmZvb3Rlci1uYXZpZ2F0aW9uIC5sYW5ndWFnZS13cmFwcGVyLmNsYXNzLXRvZ2dsZS1hY3RpdmUgLmRyb3Bkb3duLWNvbnRlbnQgYSB7XG4gIGNvbG9yOiB2YXIoLS1ibGFjayk7XG4gIHBhZGRpbmc6IDAuMzc1ZW0gMC43NWVtO1xufVxuI2Zvb3Rlci5mLW5hdmlnYXRpb24tZm9vdGVyIC5mb290ZXItY29udGVudCAuZm9vdGVyLW5hdmlnYXRpb24gLmxhbmd1YWdlLXdyYXBwZXIgLmRyb3Bkb3duLWNvbnRlbnQge1xuICBiYWNrZ3JvdW5kOiB2YXIoLS13aGl0ZSk7XG4gIGJvcmRlci1yYWRpdXM6IDAuMjVlbTtcbiAgLXdlYmtpdC1ib3gtc2hhZG93OiAwcHggMS4xcHggNC4wNXB4IC0wLjY2cHggcmdiYSgwLCAwLCAwLCAwLjE0KSwgMHB4IDNweCA0LjVweCAwLjNweCByZ2JhKDAsIDAsIDAsIDAuMDM2KSwgMHB4IDIuOXB4IDZweCAwLjJweCByZ2JhKDAsIDAsIDAsIDAuMDYpO1xuICBib3gtc2hhZG93OiAwcHggMS4xcHggNC4wNXB4IC0wLjY2cHggcmdiYSgwLCAwLCAwLCAwLjE0KSwgMHB4IDNweCA0LjVweCAwLjNweCByZ2JhKDAsIDAsIDAsIDAuMDM2KSwgMHB4IDIuOXB4IDZweCAwLjJweCByZ2JhKDAsIDAsIDAsIDAuMDYpO1xuICAtd2Via2l0LWJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gIGhlaWdodDogMDtcbiAgbGluZS1oZWlnaHQ6IDA7XG4gIG9wYWNpdHk6IDA7XG4gIG92ZXJmbG93OiBoaWRkZW47XG4gIHBhZGRpbmc6IDA7XG4gIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgLXdlYmtpdC10cmFuc2Zvcm0tb3JpZ2luOiBjZW50ZXIgdG9wO1xuICB0cmFuc2Zvcm0tb3JpZ2luOiBjZW50ZXIgdG9wO1xuICAtd2Via2l0LXRyYW5zaXRpb246IG9wYWNpdHkgMC4yNXMgY3ViaWMtYmV6aWVyKDAuNzcsIDAsIDAuMTc1LCAxKSwgdmlzaWJpbGl0eSAwLjI1cyBjdWJpYy1iZXppZXIoMC43NywgMCwgMC4xNzUsIDEpO1xuICB0cmFuc2l0aW9uOiBvcGFjaXR5IDAuMjVzIGN1YmljLWJlemllcigwLjc3LCAwLCAwLjE3NSwgMSksIHZpc2liaWxpdHkgMC4yNXMgY3ViaWMtYmV6aWVyKDAuNzcsIDAsIDAuMTc1LCAxKTtcbiAgdmlzaWJpbGl0eTogaGlkZGVuO1xuICB3aGl0ZS1zcGFjZTogbm93cmFwO1xuICB6LWluZGV4OiAxMDAwO1xufVxuI2Zvb3Rlci5mLW5hdmlnYXRpb24tZm9vdGVyIC5mb290ZXItY29udGVudCAuZm9vdGVyLW5hdmlnYXRpb24gLmxhbmd1YWdlLXdyYXBwZXIgLmRyb3Bkb3duLWNvbnRlbnQ6OmFmdGVyIHtcbiAgYmFja2dyb3VuZDogdmFyKC0td2hpdGUpO1xuICBib3JkZXItcmFkaXVzOiAxLjI1ZW0gMCAwO1xuICBib3R0b206IC03cHg7XG4gIGNvbnRlbnQ6IFwiXCI7XG4gIGhlaWdodDogMTRweDtcbiAgbGVmdDogMTAlO1xuICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gIC13ZWJraXQtdHJhbnNmb3JtOiByb3RhdGUoNDVkZWcpO1xuICB0cmFuc2Zvcm06IHJvdGF0ZSg0NWRlZyk7XG4gIC13ZWJraXQtdHJhbnNpdGlvbjogbGVmdCAwLjI1cyBjdWJpYy1iZXppZXIoMC43NywgMCwgMC4xNzUsIDEpO1xuICB0cmFuc2l0aW9uOiBsZWZ0IDAuMjVzIGN1YmljLWJlemllcigwLjc3LCAwLCAwLjE3NSwgMSk7XG4gIHdpZHRoOiAxNHB4O1xufVxuI2Zvb3Rlci5mLW5hdmlnYXRpb24tZm9vdGVyIC5mb290ZXItY29udGVudCAuZm9vdGVyLW5hdmlnYXRpb24gLmxhbmd1YWdlLXdyYXBwZXIgLmRyb3Bkb3duLWNvbnRlbnQudG9wIHtcbiAgYm90dG9tOiBjYWxjKDEwMCUgKyAxNHB4KTtcbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZm9vdGVyLWNvbnRlbnQgLmZvb3Rlci1uYXZpZ2F0aW9uIC5sYW5ndWFnZS13cmFwcGVyIC5kcm9wZG93bi1jb250ZW50LnJpZ2h0IHtcbiAgbGVmdDogMDtcbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZm9vdGVyLWNvbnRlbnQgLmZvb3Rlci1uYXZpZ2F0aW9uIC5sYW5ndWFnZS13cmFwcGVyIC5sYW5ndWFnZS1zZWxlY3RvciB7XG4gIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gIC13ZWJraXQtYm94LWFsaWduOiBjZW50ZXI7XG4gIGN1cnNvcjogcG9pbnRlcjtcbiAgZGlzcGxheTogLXdlYmtpdC1ib3g7XG4gIGRpc3BsYXk6IC1tcy1mbGV4Ym94O1xuICBkaXNwbGF5OiBmbGV4O1xuICAtbXMtZmxleC1hbGlnbjogY2VudGVyO1xufVxuI2Zvb3Rlci5mLW5hdmlnYXRpb24tZm9vdGVyIC5mb290ZXItY29udGVudCAuZm9vdGVyLW5hdmlnYXRpb24gLmxhbmd1YWdlLXdyYXBwZXIgLmxhbmd1YWdlLXNlbGVjdG9yIC5jdXJyZW50LWxhbmd1YWdlIHtcbiAgZm9udC1zaXplOiAxLjE1ZW07XG4gIGZvbnQtd2VpZ2h0OiA2MDA7XG4gIHBhZGRpbmctbGVmdDogMC41ZW07XG59XG4jZm9vdGVyLmYtbmF2aWdhdGlvbi1mb290ZXIgLmZvb3Rlci1jb250ZW50IC5mb290ZXItbmF2aWdhdGlvbiAubmF2aWdhdGlvbiB7XG4gIGZsZXgtd3JhcDogd3JhcDtcbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZm9vdGVyLWNvbnRlbnQgLmZvb3Rlci1uYXZpZ2F0aW9uIC5uYXZpZ2F0aW9uIGEge1xuICBjb2xvcjogdmFyKC0td2hpdGUpO1xuICBmb250LXdlaWdodDogNjAwO1xuICBwYWRkaW5nLWJvdHRvbTogMWVtO1xufVxuI2Zvb3Rlci5mLW5hdmlnYXRpb24tZm9vdGVyIC5mb290ZXItY29udGVudCAuZm9vdGVyLW5hdmlnYXRpb24gLm5hdmlnYXRpb24gYTpob3ZlciB7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTUpO1xufVxuI2Zvb3Rlci5mLW5hdmlnYXRpb24tZm9vdGVyIC5mb290ZXItY29udGVudCAuZm9vdGVyLW5hdmlnYXRpb24gLm5hdmlnYXRpb24gZGl2IHtcbiAgYm94LXNpemluZzogYm9yZGVyLWJveDtcbiAgcGFkZGluZy1yaWdodDogMDtcbiAgd2lkdGg6IDEwMCU7XG59XG5AbWVkaWEgc2NyZWVuIGFuZCAobWluLXdpZHRoOiA3NjdweCkge1xuICAjZm9vdGVyLmYtbmF2aWdhdGlvbi1mb290ZXIgLmZvb3Rlci1jb250ZW50IC5mb290ZXItbmF2aWdhdGlvbiAubmF2aWdhdGlvbiBkaXYge1xuICAgIHdpZHRoOiBpbml0aWFsO1xuICB9XG59XG5AbWVkaWEgKG1pbi13aWR0aDogOTAwcHgpIHtcbiAgI2Zvb3Rlci5mLW5hdmlnYXRpb24tZm9vdGVyIC5mb290ZXItY29udGVudCAuZm9vdGVyLW5hdmlnYXRpb24gLm5hdmlnYXRpb24gZGl2IHtcbiAgICBwYWRkaW5nLXJpZ2h0OiA0ZW07XG4gIH1cbn1cbkBtZWRpYSAobWluLXdpZHRoOiA3NjhweCkgYW5kIChtYXgtd2lkdGg6IDk3OXB4KSB7XG4gICNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZm9vdGVyLWNvbnRlbnQgLmZvb3Rlci1uYXZpZ2F0aW9uIC5uYXZpZ2F0aW9uIGRpdiB7XG4gICAgcGFkZGluZy1yaWdodDogM2VtO1xuICB9XG59XG4jZm9vdGVyLmYtbmF2aWdhdGlvbi1mb290ZXIgLmZvb3Rlci1jb250ZW50IC5mb290ZXItbmF2aWdhdGlvbiAubmF2aWdhdGlvbiBkaXYgLm5hdi1pdGVtLWhlYWRlciB7XG4gIGZvbnQtc2l6ZTogMC44MzMxMjVlbTtcbiAgZm9udC13ZWlnaHQ6IDQwMDtcbiAgbGV0dGVyLXNwYWNpbmc6IDFweDtcbiAgbWFyZ2luLWJvdHRvbTogMDtcbiAgdGV4dC10cmFuc2Zvcm06IHVwcGVyY2FzZTtcbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZm9vdGVyLWNvbnRlbnQgLmZvb3Rlci1saWZlcmF5LWNvbm5lY3Qge1xuICAtd2Via2l0LWJveC1mbGV4OiAxO1xuICAtbXMtZmxleDogMTtcbiAgZmxleDogMTtcbiAgcGFkZGluZy10b3A6IDRlbTtcbn1cbkBtZWRpYSBzY3JlZW4gYW5kIChtaW4td2lkdGg6IDc2N3B4KSB7XG4gICNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZm9vdGVyLWNvbnRlbnQgLmZvb3Rlci1saWZlcmF5LWNvbm5lY3Qge1xuICAgIHBhZGRpbmctdG9wOiAwO1xuICB9XG59XG4jZm9vdGVyLmYtbmF2aWdhdGlvbi1mb290ZXIgLmZvb3Rlci1jb250ZW50IC5mb290ZXItbGlmZXJheS1jb25uZWN0IC5zb2NpYWwtbmF2IHtcbiAgbWFyZ2luLWxlZnQ6IC0xZW07XG4gIG1hcmdpbi1yaWdodDogLTFlbTtcbiAgcGFkZGluZy1sZWZ0OiAwLjVlbTtcbiAgcGFkZGluZy1yaWdodDogMC41ZW07XG59XG5AbWVkaWEgc2NyZWVuIGFuZCAobWluLXdpZHRoOiA3NjdweCkge1xuICAjZm9vdGVyLmYtbmF2aWdhdGlvbi1mb290ZXIgLmZvb3Rlci1jb250ZW50IC5mb290ZXItbGlmZXJheS1jb25uZWN0IC5zb2NpYWwtbmF2IHtcbiAgICBtYXJnaW4tbGVmdDogMDtcbiAgfVxufVxuI2Zvb3Rlci5mLW5hdmlnYXRpb24tZm9vdGVyIC5mb290ZXItY29udGVudCAuZm9vdGVyLWxpZmVyYXktY29ubmVjdCAuc29jaWFsLW5hdiBhIHtcbiAgY29sb3I6IHZhcigtLXdoaXRlKTtcbiAgaGVpZ2h0OiAzLjI1ZW07XG59XG4jZm9vdGVyLmYtbmF2aWdhdGlvbi1mb290ZXIgLmZvb3Rlci1jb250ZW50IC5mb290ZXItbGlmZXJheS1jb25uZWN0IC5zb2NpYWwtbmF2IHN2ZyB7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgZmlsbDogdmFyKC0td2hpdGUpO1xuICBoZWlnaHQ6IDEuMjVlbTtcbiAgbWFyZ2luOiAwLjVlbTtcbiAgLXdlYmtpdC10cmFuc2l0aW9uOiBhbGwgMC4yNXMgZWFzZS1pbi1vdXQ7XG4gIHRyYW5zaXRpb246IGFsbCAwLjI1cyBlYXNlLWluLW91dDtcbiAgd2lkdGg6IDEuMjVlbTtcbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZm9vdGVyLWNvbnRlbnQgLmZvb3Rlci1saWZlcmF5LWNvbm5lY3QgLmNvbnRhY3QtaW5mbyB7XG4gIGNvbG9yOiB2YXIoLS13aGl0ZSk7XG4gIHRleHQtYWxpZ246IGxlZnQ7XG59XG5AbWVkaWEgc2NyZWVuIGFuZCAobWluLXdpZHRoOiA3NjdweCkge1xuICAjZm9vdGVyLmYtbmF2aWdhdGlvbi1mb290ZXIgLmZvb3Rlci1jb250ZW50IC5mb290ZXItbGlmZXJheS1jb25uZWN0IC5jb250YWN0LWluZm8ge1xuICAgIHRleHQtYWxpZ246IHJpZ2h0O1xuICB9XG59XG4jZm9vdGVyLmYtbmF2aWdhdGlvbi1mb290ZXIgLmZvb3Rlci1jb250ZW50IC5mb290ZXItbGlmZXJheS1jb25uZWN0IC5jb250YWN0LWluZm8gYSB7XG4gIGNvbG9yOiB2YXIoLS13aGl0ZSk7XG4gIGN1cnNvcjogcG9pbnRlcjtcbiAgbGluZS1oZWlnaHQ6IDEuNWVtO1xuICBtYXJnaW46IDA7XG4gIHBhZGRpbmc6IDEuNWVtIDA7XG59XG4jZm9vdGVyLmYtbmF2aWdhdGlvbi1mb290ZXIgLmZvb3Rlci1jb250ZW50IC5mb290ZXItbGlmZXJheS1jb25uZWN0IC5jb250YWN0LWluZm8gcCB7XG4gIGZvbnQtc2l6ZTogMS4xMjVlbTtcbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZmluZS1wcmludCB7XG4gIGJhY2tncm91bmQtY29sb3I6IHZhcigtLWFjY2VudC0xMCk7XG4gIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gIGNvbG9yOiB2YXIoLS1uZXV0cmFsLTcpO1xuICBkaXNwbGF5OiBmbGV4O1xuICBmbGV4LXdyYXA6IHdyYXA7XG4gIHBhZGRpbmc6IDJlbSAwIDVlbTtcbiAgdGV4dC1hbGlnbjogbGVmdDtcbn1cbiNmb290ZXIuZi1uYXZpZ2F0aW9uLWZvb3RlciAuZmluZS1wcmludCBhIHtcbiAgY29sb3I6IHZhcigtLW5ldXRyYWwtNyk7XG4gIGZvbnQtc2l6ZTogMC45ZW07XG4gIHdpZHRoOiAxMDAlO1xufVxuQG1lZGlhIHNjcmVlbiBhbmQgKG1pbi13aWR0aDogNzY3cHgpIHtcbiAgI2Zvb3Rlci5mLW5hdmlnYXRpb24tZm9vdGVyIC5maW5lLXByaW50IGEge1xuICAgIHdpZHRoOiBpbml0aWFsO1xuICB9XG59XG4jZm9vdGVyLmYtbmF2aWdhdGlvbi1mb290ZXIgLmZpbmUtcHJpbnQgYTpob3ZlciB7XG4gIGNvbG9yOiB2YXIoLS1ibGFjayk7XG59XG4jZm9vdGVyLmYtbmF2aWdhdGlvbi1mb290ZXIgLmZpbmUtcHJpbnQgcCB7XG4gIGZvbnQtc2l6ZTogMC45ZW07XG4gIHdpZHRoOiAxMDAlO1xufVxuQG1lZGlhIHNjcmVlbiBhbmQgKG1pbi13aWR0aDogNzY3cHgpIHtcbiAgI2Zvb3Rlci5mLW5hdmlnYXRpb24tZm9vdGVyIC5maW5lLXByaW50IHAge1xuICAgIHdpZHRoOiBpbml0aWFsO1xuICB9XG59XG5cbmh0bWw6bm90KCNfXyk6bm90KCNfX18pIGJvZHkgLnBhZ2UtZWRpdG9yX19sYXlvdXQtdmlld3BvcnQtLXNpemUtdGFibGV0LFxuaHRtbDpub3QoI19fKTpub3QoI19fXykgYm9keSAucGFnZS1lZGl0b3JfX2xheW91dC12aWV3cG9ydC0tc2l6ZS1sYW5kc2NhcGVNb2JpbGUsXG5odG1sOm5vdCgjX18pOm5vdCgjX19fKSBib2R5IC5wYWdlLWVkaXRvcl9fbGF5b3V0LXZpZXdwb3J0LS1zaXplLXBvcnRyYWl0TW9iaWxlIHtcbiAgaGVpZ2h0OiAxMDB2aDtcbn0iXX0= */

--- a/workspaces/liferay-dotcom-workspace/client-extensions/liferay-dotcom-foundations-global-css/client-extension.yaml
+++ b/workspaces/liferay-dotcom-workspace/client-extensions/liferay-dotcom-foundations-global-css/client-extension.yaml
@@ -1,0 +1,7 @@
+assemble:
+    -   from: assets
+        into: static
+liferay-dotcom-foundations-global-css:
+    name: Liferay Dotcom Foundations Global CSS
+    type: globalCSS
+    url: foundations.css


### PR DESCRIPTION
Migrates the foundations theme contributor (Bundle-SymbolicName com.liferay.osb.www.foundations.theme.contributor) from lfris-www/liferay/modules/extensions/foundations into the liferay-dotcom-workspace as a globalCSS client extension.

Compiled output from the original Liferay Sass + autoprefixer pipeline (osb-foundations-theme-contributor.scss, 27 SCSS partials) is shipped as a single foundations.css asset.

Paired with DG-X removal of the source module in lfris-www (branch DG-X-remove-foundations).